### PR TITLE
Add Advance call to protocol reader

### DIFF
--- a/BedrockFramework.sln
+++ b/BedrockFramework.sln
@@ -11,7 +11,20 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServerApplication", "sample
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DistributedApplication", "samples\DistributedApplication\DistributedApplication.csproj", "{CC34D2C9-A20F-4E20-A9E0-973754F019ED}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DistributedApplication.ServiceRegistry", "samples\DistributedApplication.ServiceRegistry\DistributedApplication.ServiceRegistry.csproj", "{5531B956-7D0A-4670-A811-AC8DC8CE423F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DistributedApplication.ServiceRegistry", "samples\DistributedApplication.ServiceRegistry\DistributedApplication.ServiceRegistry.csproj", "{5531B956-7D0A-4670-A811-AC8DC8CE423F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{BE56BD3F-A489-42F7-A3E3-93AE5A0A54E2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{B0C0F79A-2A88-4ADB-9E15-62C1EA26A96D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1F47B42E-790F-48AA-8BFB-AD1986D05A67}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bedrock.Framework.Tests", "tests\Bedrock.Framework.Tests\Bedrock.Framework.Tests.csproj", "{37FED75D-A02F-43AF-B888-F331634C3FA7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EA6E96E9-C7CC-4051-8E3A-28236CE32CFD}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,9 +52,21 @@ Global
 		{5531B956-7D0A-4670-A811-AC8DC8CE423F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5531B956-7D0A-4670-A811-AC8DC8CE423F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5531B956-7D0A-4670-A811-AC8DC8CE423F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{37FED75D-A02F-43AF-B888-F331634C3FA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{37FED75D-A02F-43AF-B888-F331634C3FA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{37FED75D-A02F-43AF-B888-F331634C3FA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{37FED75D-A02F-43AF-B888-F331634C3FA7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{44A257ED-D3A7-4170-BE67-4392F2A6FE18} = {B0C0F79A-2A88-4ADB-9E15-62C1EA26A96D}
+		{53CD2C10-7FA3-4816-A44B-66E11B656102} = {BE56BD3F-A489-42F7-A3E3-93AE5A0A54E2}
+		{4CB0147D-BCEB-43A7-8F21-D144F7E9B462} = {B0C0F79A-2A88-4ADB-9E15-62C1EA26A96D}
+		{CC34D2C9-A20F-4E20-A9E0-973754F019ED} = {B0C0F79A-2A88-4ADB-9E15-62C1EA26A96D}
+		{5531B956-7D0A-4670-A811-AC8DC8CE423F} = {B0C0F79A-2A88-4ADB-9E15-62C1EA26A96D}
+		{37FED75D-A02F-43AF-B888-F331634C3FA7} = {1F47B42E-790F-48AA-8BFB-AD1986D05A67}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {05222274-E7CB-4ABA-9ADF-4A3DBB1D0417}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>cloud microservice networking sockets websockets tcp</PackageTags>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="$(IsPackable) == 'true'">
     <PackageReference Include="Nerdbank.GitVersioning">
       <Version>3.0.28</Version>
       <PrivateAssets>all</PrivateAssets>

--- a/samples/ServerApplication/MyCustomProtocol.cs
+++ b/samples/ServerApplication/MyCustomProtocol.cs
@@ -31,7 +31,6 @@ namespace ServerApplication
 
                     _logger.LogInformation("Received a message of {Length} bytes", message.Payload.Length);
 
-                    // REVIEW: We need a ReadResult<T> to indicate completion and cancellation
                     if (result.IsCompleted)
                     {
                         break;

--- a/samples/ServerApplication/MyCustomProtocol.cs
+++ b/samples/ServerApplication/MyCustomProtocol.cs
@@ -24,14 +24,22 @@ namespace ServerApplication
 
             while (true)
             {
-                var message = await reader.ReadAsync();
-
-                _logger.LogInformation("Received a message of {Length} bytes", message.Payload.Length);
-
-                // REVIEW: We need a ReadResult<T> to indicate completion and cancellation
-                if (message.Payload == null)
+                try
                 {
-                    break;
+                    var result = await reader.ReadAsync();
+                    var message = result.Message;
+
+                    _logger.LogInformation("Received a message of {Length} bytes", message.Payload.Length);
+
+                    // REVIEW: We need a ReadResult<T> to indicate completion and cancellation
+                    if (result.IsCompleted)
+                    {
+                        break;
+                    }
+                }
+                finally
+                {
+                    reader.Advance();
                 }
             }
         }

--- a/src/Bedrock.Framework/Protocols/Protocol.cs
+++ b/src/Bedrock.Framework/Protocols/Protocol.cs
@@ -120,7 +120,12 @@ namespace Bedrock.Framework.Protocols
                     {
                         if (reader.TryParseMessage(buffer, out _consumed, out _examined, out protocolMessage))
                         {
-                            return new ReadResult<TReadMessage>(protocolMessage, isCanceled, isCompleted);
+                            return new ReadResult<TReadMessage>(protocolMessage, isCanceled, isCompleted: false);
+                        }
+                        else
+                        {
+                            // No message so advance
+                            input.AdvanceTo(_consumed, _examined);
                         }
                     }
                     else
@@ -141,7 +146,7 @@ namespace Bedrock.Framework.Protocols
 
                             if (reader.TryParseMessage(segment, out _consumed, out _examined, out protocolMessage))
                             {
-                                return new ReadResult<TReadMessage>(protocolMessage, isCanceled, isCompleted);
+                                return new ReadResult<TReadMessage>(protocolMessage, isCanceled, isCompleted: false);
                             }
                             else if (overLength)
                             {
@@ -149,6 +154,7 @@ namespace Bedrock.Framework.Protocols
                             }
                             else
                             {
+                                input.AdvanceTo(_consumed, _examined);
                                 // No need to update the buffer since we didn't parse anything
                                 continue;
                             }
@@ -171,6 +177,7 @@ namespace Bedrock.Framework.Protocols
 
         public void Advance()
         {
+            // TODO: More error handling here
             Connection.Transport.Input.AdvanceTo(_consumed, _examined);
         }
     }

--- a/tests/Bedrock.Framework.Tests/Bedrock.Framework.Tests.csproj
+++ b/tests/Bedrock.Framework.Tests/Bedrock.Framework.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\Bedrock.Framework\Infrastructure\DuplexPipe.cs" Link="Infrastructure\DuplexPipe.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Bedrock.Framework\Bedrock.Framework.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Infrastructure\" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Bedrock.Framework.Tests/ProtocolTests.cs
+++ b/tests/Bedrock.Framework.Tests/ProtocolTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Text;
+using System.Threading.Tasks;
+using Bedrock.Framework.Protocols;
+using Microsoft.AspNetCore.Connections;
+using Xunit;
+
+namespace Bedrock.Framework.Tests
+{
+    public class ProtocolTests
+    {
+        [Fact]
+        public async Task ReadMessagesWorks()
+        {
+            var options = new PipeOptions(useSynchronizationContext: false);
+            var pair = DuplexPipe.CreateConnectionPair(options, options);
+            await using var connection = new DefaultConnectionContext(Guid.NewGuid().ToString(), pair.Transport, pair.Application);
+            var data = Encoding.UTF8.GetBytes("Hello World");
+            for (int i = 0; i < 3; i++)
+            {
+                await connection.Application.Output.WriteAsync(data);
+            }
+            connection.Application.Output.Complete();
+
+            var reader = Protocol.CreateReader(connection, new MyProtocolReader(data.Length));
+            var count = 0;
+
+            while (true)
+            {
+                var result = await reader.ReadAsync();
+
+                if (result.IsCompleted)
+                {
+                    break;
+                }
+
+                count++;
+                Assert.Equal(data, result.Message);
+
+                reader.Advance();
+            }
+
+            Assert.Equal(3, count);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(20)]
+        public async Task PartialMessageWorks(int? maxMessageSize)
+        {
+            var options = new PipeOptions(useSynchronizationContext: false);
+            var pair = DuplexPipe.CreateConnectionPair(options, options);
+            await using var connection = new DefaultConnectionContext(Guid.NewGuid().ToString(), pair.Transport, pair.Application);
+            var data = Encoding.UTF8.GetBytes("Hello World");
+            var reader = Protocol.CreateReader(connection, new MyProtocolReader(data.Length), maxMessageSize);
+            var resultTask = reader.ReadAsync();
+
+            // Write byte by byte
+            for (int i = 0; i < data.Length; i++)
+            {
+                await connection.Application.Output.WriteAsync(data.AsMemory(i, 1));
+            }
+
+            var result = await resultTask;
+            Assert.Equal(data, result.Message);
+            reader.Advance();
+        }
+
+        [Fact]
+        public async Task ReadingWithoutCallingAdvanceThrows()
+        {
+            var options = new PipeOptions(useSynchronizationContext: false);
+            var pair = DuplexPipe.CreateConnectionPair(options, options);
+            await using var connection = new DefaultConnectionContext(Guid.NewGuid().ToString(), pair.Transport, pair.Application);
+            var data = Encoding.UTF8.GetBytes("Hello World");
+            var reader = Protocol.CreateReader(connection, new MyProtocolReader(data.Length));
+            
+            await connection.Application.Output.WriteAsync(data);
+            var result = await reader.ReadAsync();
+            Assert.Equal(data, result.Message);
+
+            // REVIEW: This only throws today because the underlying pipe throws, we should make this work properly
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await reader.ReadAsync());
+        }
+
+        public class MyProtocolReader : IProtocolReader<byte[]>
+        {
+            public MyProtocolReader(int messageLength)
+            {
+                MessageLength = messageLength;
+            }
+
+            public int MessageLength { get; }
+
+            public bool TryParseMessage(in ReadOnlySequence<byte> input, out SequencePosition consumed, out SequencePosition examined, out byte[] message)
+            {
+                consumed = input.Start;
+                examined = input.End;
+
+                if (input.Length < MessageLength)
+                {
+                    message = default;
+                    return false;
+                }
+
+                var buffer = input.Slice(0, MessageLength);
+                message = buffer.ToArray();
+                consumed = buffer.End;
+                examined = buffer.End;
+
+                return true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- To allow `IProtocolReader<TMessage>` to avoid copying incoming `byte[]` directly, we add an `Advance()` method to the reader to allow the caller to decide when memory is recycled.
- This also exposed a `ReadResult<TMessage>` to propagate cancellation and completion information.

cc @JanEggers 