### PR TITLE
Changes to protocol reading and writing

### DIFF
--- a/samples/ClientApplication/Program.cs
+++ b/samples/ClientApplication/Program.cs
@@ -220,14 +220,14 @@ namespace ClientApplication
             Console.WriteLine($"Connected to {connection.LocalEndPoint}");
 
             var protocol = new LengthPrefixedProtocol();
-            var reader = connection.CreateReader(protocol);
-            var writer = connection.CreateWriter(protocol);
+            var reader = connection.CreateReader();
+            var writer = connection.CreateWriter();
 
             while (true)
             {
                 var line = Console.ReadLine();
-                await writer.WriteAsync(new Message(Encoding.UTF8.GetBytes(line)));
-                var result = await reader.ReadAsync();
+                await writer.WriteAsync(protocol, new Message(Encoding.UTF8.GetBytes(line)));
+                var result = await reader.ReadAsync(protocol);
 
                 if (result.IsCompleted)
                 {

--- a/samples/ServerApplication/LengthPrefixedProtocol.cs
+++ b/samples/ServerApplication/LengthPrefixedProtocol.cs
@@ -5,7 +5,7 @@ using Bedrock.Framework.Protocols;
 
 namespace Protocols
 {
-    public class LengthPrefixedProtocol : IProtocolReader<Message>, IProtocolWriter<Message>
+    public class LengthPrefixedProtocol : IMessageReader<Message>, IMessageWriter<Message>
     {
         public bool TryParseMessage(in ReadOnlySequence<byte> input, out SequencePosition consumed, out SequencePosition examined, out Message message)
         {

--- a/samples/ServerApplication/MyCustomProtocol.cs
+++ b/samples/ServerApplication/MyCustomProtocol.cs
@@ -19,14 +19,14 @@ namespace ServerApplication
         {
             // Use a length prefixed protocol
             var protocol = new LengthPrefixedProtocol();
-            var reader = connection.CreateReader(protocol);
-            var writer = connection.CreateWriter(protocol);
+            var reader = connection.CreateReader();
+            var writer = connection.CreateWriter();
 
             while (true)
             {
                 try
                 {
-                    var result = await reader.ReadAsync();
+                    var result = await reader.ReadAsync(protocol);
                     var message = result.Message;
 
                     _logger.LogInformation("Received a message of {Length} bytes", message.Payload.Length);
@@ -36,7 +36,7 @@ namespace ServerApplication
                         break;
                     }
 
-                    await writer.WriteAsync(message);
+                    await writer.WriteAsync(protocol, message);
                 }
                 finally
                 {

--- a/src/Bedrock.Framework/Protocols/Http1RequestMessageReader.cs
+++ b/src/Bedrock.Framework/Protocols/Http1RequestMessageReader.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Bedrock.Framework.Protocols
 {
-    public class Http1RequestMessageReader : IProtocolReader<HttpRequestMessage>
+    public class Http1RequestMessageReader : IMessageReader<HttpRequestMessage>
     {
         private ReadOnlySpan<byte> NewLine => new byte[] { (byte)'\r', (byte)'\n' };
         private ReadOnlySpan<byte> TrimChars => new byte[] { (byte)' ', (byte)'\t' };

--- a/src/Bedrock.Framework/Protocols/Http1RequestMessageWriter.cs
+++ b/src/Bedrock.Framework/Protocols/Http1RequestMessageWriter.cs
@@ -6,7 +6,7 @@ using Bedrock.Framework.Infrastructure;
 
 namespace Bedrock.Framework.Protocols
 {
-    public class Http1RequestMessageWriter : IProtocolWriter<HttpRequestMessage>
+    public class Http1RequestMessageWriter : IMessageWriter<HttpRequestMessage>
     {
         private ReadOnlySpan<byte> Http11 => new byte[] { (byte)'H', (byte)'T', (byte)'T', (byte)'P', (byte)'/', (byte)'1', (byte)'.', (byte)'1' };
         private ReadOnlySpan<byte> NewLine => new byte[] { (byte)'\r', (byte)'\n' };

--- a/src/Bedrock.Framework/Protocols/Http1ResponseMessageReader.cs
+++ b/src/Bedrock.Framework/Protocols/Http1ResponseMessageReader.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace Bedrock.Framework.Protocols
 {
-    public class Http1ResponseMessageReader : IProtocolReader<HttpResponseMessage>
+    public class Http1ResponseMessageReader : IMessageReader<HttpResponseMessage>
     {
         private ReadOnlySpan<byte> NewLine => new byte[] { (byte)'\r', (byte)'\n' };
         private ReadOnlySpan<byte> TrimChars => new byte[] { (byte)' ', (byte)'\t' };

--- a/src/Bedrock.Framework/Protocols/Http1ResponseMessageWriter.cs
+++ b/src/Bedrock.Framework/Protocols/Http1ResponseMessageWriter.cs
@@ -6,7 +6,7 @@ using Bedrock.Framework.Infrastructure;
 
 namespace Bedrock.Framework.Protocols
 {
-    public class Http1ResponseMessageWriter : IProtocolWriter<HttpResponseMessage>
+    public class Http1ResponseMessageWriter : IMessageWriter<HttpResponseMessage>
     {
         private ReadOnlySpan<byte> NewLine => new byte[] { (byte)'\r', (byte)'\n' };
         private ReadOnlySpan<byte> Space => new byte[] { (byte)' ' };

--- a/src/Bedrock.Framework/Protocols/HubHandshakeMessageReader.cs
+++ b/src/Bedrock.Framework/Protocols/HubHandshakeMessageReader.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.SignalR.Protocol;
 
 namespace Bedrock.Framework.Protocols
 {
-    public class HubHandshakeProtocolReader : IProtocolReader<HandshakeRequestMessage>
+    public class HubHandshakeMessageReader : IMessageReader<HandshakeRequestMessage>
     {
         public bool TryParseMessage(in ReadOnlySequence<byte> input, out SequencePosition consumed, out SequencePosition examined, out HandshakeRequestMessage message)
         {

--- a/src/Bedrock.Framework/Protocols/HubMessageReader.cs
+++ b/src/Bedrock.Framework/Protocols/HubMessageReader.cs
@@ -5,12 +5,12 @@ using Microsoft.AspNetCore.SignalR.Protocol;
 
 namespace Bedrock.Framework.Protocols
 {
-    public class HubProtocolReader : IProtocolReader<HubMessage>
+    public class HubMessageReader : IMessageReader<HubMessage>
     {
         private readonly IHubProtocol _hubProtocol;
         private readonly IInvocationBinder _invocationBinder;
 
-        public HubProtocolReader(IHubProtocol hubProtocol, IInvocationBinder invocationBinder)
+        public HubMessageReader(IHubProtocol hubProtocol, IInvocationBinder invocationBinder)
         {
             _hubProtocol = hubProtocol;
             _invocationBinder = invocationBinder;

--- a/src/Bedrock.Framework/Protocols/HubMessageWriter.cs
+++ b/src/Bedrock.Framework/Protocols/HubMessageWriter.cs
@@ -6,11 +6,11 @@ using Microsoft.AspNetCore.SignalR.Protocol;
 
 namespace Bedrock.Framework.Protocols
 {
-    public class HubProtocolWriter : IProtocolWriter<HubMessage>
+    public class HubMessageWriter : IMessageWriter<HubMessage>
     {
         private readonly IHubProtocol _hubProtocol;
 
-        public HubProtocolWriter(IHubProtocol hubProtocol)
+        public HubMessageWriter(IHubProtocol hubProtocol)
         {
             _hubProtocol = hubProtocol;
         }

--- a/src/Bedrock.Framework/Protocols/IMessageReader.cs
+++ b/src/Bedrock.Framework/Protocols/IMessageReader.cs
@@ -3,7 +3,7 @@ using System.Buffers;
 
 namespace Bedrock.Framework.Protocols
 {
-    public interface IProtocolReader<TMessage>
+    public interface IMessageReader<TMessage>
     {
         bool TryParseMessage(in ReadOnlySequence<byte> input, out SequencePosition consumed, out SequencePosition examined, out TMessage message);
     }

--- a/src/Bedrock.Framework/Protocols/IMessageWriter.cs
+++ b/src/Bedrock.Framework/Protocols/IMessageWriter.cs
@@ -2,7 +2,7 @@
 
 namespace Bedrock.Framework.Protocols
 {
-    public interface IProtocolWriter<TMessage>
+    public interface IMessageWriter<TMessage>
     {
         void WriteMessage(TMessage message, IBufferWriter<byte> output);
     }

--- a/src/Bedrock.Framework/Protocols/Protocol.cs
+++ b/src/Bedrock.Framework/Protocols/Protocol.cs
@@ -5,13 +5,13 @@ namespace Bedrock.Framework.Protocols
 {
     public static class Protocol
     {
-        public static ProtocolWriter<TWriteMessage> CreateWriter<TWriteMessage>(this ConnectionContext connection, IProtocolWriter<TWriteMessage> writer)
-            => new ProtocolWriter<TWriteMessage>(connection, writer);
+        public static ProtocolWriter CreateWriter(this ConnectionContext connection)
+            => new ProtocolWriter(connection);
 
-        public static ProtocolWriter<TWriteMessage> CreateWriter<TWriteMessage>(this ConnectionContext connection, IProtocolWriter<TWriteMessage> writer, SemaphoreSlim semaphore)
-            => new ProtocolWriter<TWriteMessage>(connection, writer, semaphore);
+        public static ProtocolWriter CreateWriter(this ConnectionContext connection, SemaphoreSlim semaphore)
+            => new ProtocolWriter(connection, semaphore);
 
-        public static ProtocolReader<TReadMessage> CreateReader<TReadMessage>(this ConnectionContext connection, IProtocolReader<TReadMessage> reader, int? maximumMessageSize = null)
-            => new ProtocolReader<TReadMessage>(connection, reader, maximumMessageSize);
+        public static ProtocolReader CreateReader(this ConnectionContext connection, int? maximumMessageSize = null)
+            => new ProtocolReader(connection, maximumMessageSize);
     }
 }


### PR DESCRIPTION
- This change makes the ProtocolReader and ProtocolWriter non-generic and as such makes it possible to parse multipe types of messages on a per read/write basis. This is useful when there are mixed message types in a single protocol (like header and body).
- As a result, we can no longer store the previous message to the reader has to be advanced before reading again.
- It also allows for more advanced scenarios like reading a message then checking the state of the reader to take some action.
- Renamed IProtocolReader to IMessageWriter and IProtocolWriter to IMessageWriter

cc @JanEggers 