### PR TITLE
Change IMessageReader to use ref instead of out

### DIFF
--- a/samples/ClientApplication/Program.cs
+++ b/samples/ClientApplication/Program.cs
@@ -36,37 +36,40 @@ namespace ClientApplication
             Console.WriteLine("5. In Memory Transport Echo Server and client");
             Console.WriteLine("6. Length prefixed custom binary protocol");
 
-            var keyInfo = Console.ReadKey();
+            while (true)
+            {
+                var keyInfo = Console.ReadKey();
 
-            if (keyInfo.Key == ConsoleKey.D1)
-            {
-                Console.WriteLine("Running echo server example");
-                await EchoServer(serviceProvider);
-            }
-            else if (keyInfo.Key == ConsoleKey.D2)
-            {
-                Console.WriteLine("Running http client example");
-                await HttpClient(serviceProvider);
-            }
-            else if (keyInfo.Key == ConsoleKey.D3)
-            {
-                Console.WriteLine("Running SignalR example");
-                await SignalR();
-            }
-            else if (keyInfo.Key == ConsoleKey.D4)
-            {
-                Console.WriteLine("Running echo server with TLS example");
-                await EchoServerWithTls(serviceProvider);
-            }
-            else if (keyInfo.Key == ConsoleKey.D5)
-            {
-                Console.WriteLine("In Memory Transport Echo Server and client.");
-                await InMemoryEchoTransport(serviceProvider);
-            }
-            else if (keyInfo.Key == ConsoleKey.D6)
-            {
-                Console.WriteLine("Custom length prefixed protocol.");
-                await CustomProtocol(serviceProvider);
+                if (keyInfo.Key == ConsoleKey.D1)
+                {
+                    Console.WriteLine("Running echo server example");
+                    await EchoServer(serviceProvider);
+                }
+                else if (keyInfo.Key == ConsoleKey.D2)
+                {
+                    Console.WriteLine("Running http client example");
+                    await HttpClient(serviceProvider);
+                }
+                else if (keyInfo.Key == ConsoleKey.D3)
+                {
+                    Console.WriteLine("Running SignalR example");
+                    await SignalR();
+                }
+                else if (keyInfo.Key == ConsoleKey.D4)
+                {
+                    Console.WriteLine("Running echo server with TLS example");
+                    await EchoServerWithTls(serviceProvider);
+                }
+                else if (keyInfo.Key == ConsoleKey.D5)
+                {
+                    Console.WriteLine("In Memory Transport Echo Server and client.");
+                    await InMemoryEchoTransport(serviceProvider);
+                }
+                else if (keyInfo.Key == ConsoleKey.D6)
+                {
+                    Console.WriteLine("Custom length prefixed protocol.");
+                    await CustomProtocol(serviceProvider);
+                }
             }
         }
 

--- a/samples/ServerApplication/LengthPrefixedProtocol.cs
+++ b/samples/ServerApplication/LengthPrefixedProtocol.cs
@@ -7,13 +7,11 @@ namespace Protocols
 {
     public class LengthPrefixedProtocol : IMessageReader<Message>, IMessageWriter<Message>
     {
-        public bool TryParseMessage(in ReadOnlySequence<byte> input, out SequencePosition consumed, out SequencePosition examined, out Message message)
+        public bool TryParseMessage(in ReadOnlySequence<byte> input, ref SequencePosition consumed, ref SequencePosition examined, out Message message)
         {
             var reader = new SequenceReader<byte>(input);
             if (!reader.TryReadBigEndian(out int length) || input.Length < length)
             {
-                consumed = input.Start;
-                examined = input.End;
                 message = default;
                 return false;
             }

--- a/src/Bedrock.Framework.Experimental/Protocols/ChunkedHttpBodyReader.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/ChunkedHttpBodyReader.cs
@@ -14,19 +14,16 @@ namespace Bedrock.Framework.Protocols
 
         private bool IsCompleted { get; set; }
 
-        public bool TryParseMessage(in ReadOnlySequence<byte> input, out SequencePosition consumed, out SequencePosition examined, out ReadOnlySequence<byte> message)
+        public bool TryParseMessage(in ReadOnlySequence<byte> input, ref SequencePosition consumed, ref SequencePosition examined, out ReadOnlySequence<byte> message)
         {
             if (IsCompleted)
             {
-                consumed = input.Start;
-                examined = input.End;
                 message = default;
                 return true;
             }
 
             var sequenceReader = new SequenceReader<byte>(input);
             message = default;
-            examined = input.End;
 
             while (true)
             {

--- a/src/Bedrock.Framework.Experimental/Protocols/ContentLengthHttpBodyReader.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/ContentLengthHttpBodyReader.cs
@@ -14,12 +14,10 @@ namespace Bedrock.Framework.Protocols
             _remaining = contentLength;
         }
 
-        public bool TryParseMessage(in ReadOnlySequence<byte> input, out SequencePosition consumed, out SequencePosition examined, out ReadOnlySequence<byte> message)
+        public bool TryParseMessage(in ReadOnlySequence<byte> input, ref SequencePosition consumed, ref SequencePosition examined, out ReadOnlySequence<byte> message)
         {
             if (_remaining == 0)
             {
-                consumed = input.Start;
-                examined = input.End;
                 message = default;
                 return true;
             }

--- a/src/Bedrock.Framework.Experimental/Protocols/Http1RequestMessageReader.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Http1RequestMessageReader.cs
@@ -19,12 +19,10 @@ namespace Bedrock.Framework.Protocols
             _httpRequestMessage.Content = content;
         }
 
-        public bool TryParseMessage(in ReadOnlySequence<byte> input, out SequencePosition consumed, out SequencePosition examined, out HttpRequestMessage message)
+        public bool TryParseMessage(in ReadOnlySequence<byte> input, ref SequencePosition consumed, ref SequencePosition examined, out HttpRequestMessage message)
         {
             var sequenceReader = new SequenceReader<byte>(input);
             message = null;
-            consumed = input.Start;
-            examined = input.End;
 
             if (_state == State.StartLine)
             {

--- a/src/Bedrock.Framework.Experimental/Protocols/Http1ResponseMessageReader.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Http1ResponseMessageReader.cs
@@ -22,11 +22,9 @@ namespace Bedrock.Framework.Protocols
             _httpResponseMessage.Content = content;
         }
 
-        public bool TryParseMessage(in ReadOnlySequence<byte> input, out SequencePosition consumed, out SequencePosition examined, out HttpResponseMessage message)
+        public bool TryParseMessage(in ReadOnlySequence<byte> input, ref SequencePosition consumed, ref SequencePosition examined, out HttpResponseMessage message)
         {
             var sequenceReader = new SequenceReader<byte>(input);
-            consumed = input.Start;
-            examined = input.End;
             message = null;
 
             if (_state == State.StartLine)

--- a/src/Bedrock.Framework.Experimental/Protocols/HubHandshakeMessageReader.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/HubHandshakeMessageReader.cs
@@ -6,7 +6,7 @@ namespace Bedrock.Framework.Protocols
 {
     public class HubHandshakeMessageReader : IMessageReader<HandshakeRequestMessage>
     {
-        public bool TryParseMessage(in ReadOnlySequence<byte> input, out SequencePosition consumed, out SequencePosition examined, out HandshakeRequestMessage message)
+        public bool TryParseMessage(in ReadOnlySequence<byte> input, ref SequencePosition consumed, ref SequencePosition examined, out HandshakeRequestMessage message)
         {
             var buffer = input;
             if (HandshakeProtocol.TryParseRequestMessage(ref buffer, out message))
@@ -16,8 +16,6 @@ namespace Bedrock.Framework.Protocols
                 return true;
             }
 
-            consumed = input.Start;
-            examined = input.End;
             return false;
         }
     }

--- a/src/Bedrock.Framework.Experimental/Protocols/HubMessageReader.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/HubMessageReader.cs
@@ -16,7 +16,7 @@ namespace Bedrock.Framework.Protocols
             _invocationBinder = invocationBinder;
         }
 
-        public bool TryParseMessage(in ReadOnlySequence<byte> input, out SequencePosition consumed, out SequencePosition examined, out HubMessage message)
+        public bool TryParseMessage(in ReadOnlySequence<byte> input, ref SequencePosition consumed, ref SequencePosition examined, out HubMessage message)
         {
             var buffer = input;
             if (_hubProtocol.TryParseMessage(ref buffer, _invocationBinder, out message))
@@ -26,8 +26,6 @@ namespace Bedrock.Framework.Protocols
                 return true;
             }
 
-            consumed = input.Start;
-            examined = input.End;
             return false;
         }
     }

--- a/src/Bedrock.Framework/Protocols/IMessageReader.cs
+++ b/src/Bedrock.Framework/Protocols/IMessageReader.cs
@@ -5,6 +5,6 @@ namespace Bedrock.Framework.Protocols
 {
     public interface IMessageReader<TMessage>
     {
-        bool TryParseMessage(in ReadOnlySequence<byte> input, out SequencePosition consumed, out SequencePosition examined, out TMessage message);
+        bool TryParseMessage(in ReadOnlySequence<byte> input, ref SequencePosition consumed, ref SequencePosition examined, out TMessage message);
     }
 }

--- a/src/Bedrock.Framework/Protocols/ProtocolReader.cs
+++ b/src/Bedrock.Framework/Protocols/ProtocolReader.cs
@@ -135,7 +135,7 @@ namespace Bedrock.Framework.Protocols
             // No message limit, just parse and dispatch
             if (maximumMessageSize == null)
             {
-                if (reader.TryParseMessage(buffer, out _consumed, out _examined, out protocolMessage))
+                if (reader.TryParseMessage(buffer, ref _consumed, ref _examined, out protocolMessage))
                 {
                     return true;
                 }
@@ -155,7 +155,7 @@ namespace Bedrock.Framework.Protocols
                 overLength = true;
             }
 
-            if (reader.TryParseMessage(segment, out _consumed, out _examined, out protocolMessage))
+            if (reader.TryParseMessage(segment, ref _consumed, ref _examined, out protocolMessage))
             {
                 return true;
             }

--- a/tests/Bedrock.Framework.Tests/ProtocolTests.cs
+++ b/tests/Bedrock.Framework.Tests/ProtocolTests.cs
@@ -264,11 +264,8 @@ namespace Bedrock.Framework.Tests
 
             public int MessageLength { get; }
 
-            public bool TryParseMessage(in ReadOnlySequence<byte> input, out SequencePosition consumed, out SequencePosition examined, out byte[] message)
+            public bool TryParseMessage(in ReadOnlySequence<byte> input, ref SequencePosition consumed, ref SequencePosition examined, out byte[] message)
             {
-                consumed = input.Start;
-                examined = input.End;
-
                 if (input.Length < MessageLength)
                 {
                     message = default;


### PR DESCRIPTION
- The cursors only need to be set if data was consumed.

PS: I'm not 100% sure if being less strict about this is good but it removes some boilerplate.