### PR TITLE
Add ProtocolReader Benchmarks

### DIFF
--- a/BedrockFramework.sln
+++ b/BedrockFramework.sln
@@ -22,7 +22,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bedrock.Framework.Experimental", "src\Bedrock.Framework.Experimental\Bedrock.Framework.Experimental.csproj", "{B77439AE-01C0-4877-AF91-180D521F6E55}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bedrock.Framework.Experimental", "src\Bedrock.Framework.Experimental\Bedrock.Framework.Experimental.csproj", "{B77439AE-01C0-4877-AF91-180D521F6E55}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bedrock.Framework.Benchmarks", "tests\Bedrock.Framework.Benchmarks\Bedrock.Framework.Benchmarks.csproj", "{E4532856-96A9-47F1-9718-9FD596362493}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -50,6 +52,10 @@ Global
 		{B77439AE-01C0-4877-AF91-180D521F6E55}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B77439AE-01C0-4877-AF91-180D521F6E55}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B77439AE-01C0-4877-AF91-180D521F6E55}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4532856-96A9-47F1-9718-9FD596362493}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4532856-96A9-47F1-9718-9FD596362493}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4532856-96A9-47F1-9718-9FD596362493}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4532856-96A9-47F1-9718-9FD596362493}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -60,6 +66,7 @@ Global
 		{4CB0147D-BCEB-43A7-8F21-D144F7E9B462} = {B0C0F79A-2A88-4ADB-9E15-62C1EA26A96D}
 		{37FED75D-A02F-43AF-B888-F331634C3FA7} = {1F47B42E-790F-48AA-8BFB-AD1986D05A67}
 		{B77439AE-01C0-4877-AF91-180D521F6E55} = {BE56BD3F-A489-42F7-A3E3-93AE5A0A54E2}
+		{E4532856-96A9-47F1-9718-9FD596362493} = {1F47B42E-790F-48AA-8BFB-AD1986D05A67}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {05222274-E7CB-4ABA-9ADF-4A3DBB1D0417}

--- a/tests/Bedrock.Framework.Benchmarks/Bedrock.Framework.Benchmarks.csproj
+++ b/tests/Bedrock.Framework.Benchmarks/Bedrock.Framework.Benchmarks.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Bedrock.Framework\Bedrock.Framework.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Bedrock.Framework.Benchmarks/BenchmarkConfig.cs
+++ b/tests/Bedrock.Framework.Benchmarks/BenchmarkConfig.cs
@@ -1,0 +1,18 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using System;
+using System.IO;
+
+namespace Bedrock.Framework.Benchmarks
+{
+    public class BenchmarkConfig : ManualConfig
+    {
+        public BenchmarkConfig()
+        {
+            Add(DefaultConfig.Instance);
+            Add(MemoryDiagnoser.Default);
+
+            ArtifactsPath = Path.Combine(AppContext.BaseDirectory, "artifacts", DateTime.Now.ToString("yyyy-mm-dd_hh-MM-ss"));
+        }
+    }
+}

--- a/tests/Bedrock.Framework.Benchmarks/BenchmarkConfig.cs
+++ b/tests/Bedrock.Framework.Benchmarks/BenchmarkConfig.cs
@@ -11,7 +11,7 @@ namespace Bedrock.Framework.Benchmarks
         {
             Add(DefaultConfig.Instance);
             Add(MemoryDiagnoser.Default);
-
+            
             ArtifactsPath = Path.Combine(AppContext.BaseDirectory, "artifacts", DateTime.Now.ToString("yyyy-mm-dd_hh-MM-ss"));
         }
     }

--- a/tests/Bedrock.Framework.Benchmarks/Program.cs
+++ b/tests/Bedrock.Framework.Benchmarks/Program.cs
@@ -1,0 +1,18 @@
+﻿using BenchmarkDotNet.Running;
+using System;
+
+namespace Bedrock.Framework.Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            new BenchmarkSwitcher(AllBenchmarks).Run(args, new BenchmarkConfig());
+        }
+
+        private static readonly Type[] AllBenchmarks = new[]
+        {
+            typeof(ProtocolReaderBenchmarks)
+        };
+    }
+}

--- a/tests/Bedrock.Framework.Benchmarks/ProtocolReaderBenchmarks.cs
+++ b/tests/Bedrock.Framework.Benchmarks/ProtocolReaderBenchmarks.cs
@@ -87,7 +87,6 @@ namespace Bedrock.Framework.Benchmarks
         {
             private readonly int messageSize;
             
-
             public SimpleReader(int messageSize)
             {
                 this.messageSize = messageSize;

--- a/tests/Bedrock.Framework.Benchmarks/ProtocolReaderBenchmarks.cs
+++ b/tests/Bedrock.Framework.Benchmarks/ProtocolReaderBenchmarks.cs
@@ -1,0 +1,93 @@
+﻿using Bedrock.Framework.Protocols;
+using BenchmarkDotNet.Attributes;
+using System;
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Threading.Tasks;
+
+namespace Bedrock.Framework.Benchmarks
+{
+    public class ProtocolReaderBenchmarks
+    {
+        private Pipe dataPipe;
+        private SimpleDelimitedReader delimitedMessageReader;
+        
+        [Params(1, 10, 100, 1000, 10000)]
+        public int ChunkCount { get; set; }
+
+        [Params(10)]
+        public int ChunkSize { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            dataPipe = new Pipe();
+
+            delimitedMessageReader = new SimpleDelimitedReader(ChunkSize);
+        }
+
+        class SimpleDelimitedReader : IMessageReader<int>
+        {
+            private readonly int chunkSize;
+            
+
+            public SimpleDelimitedReader(int chunkSize)
+            {
+                this.chunkSize = chunkSize;
+            }
+
+            public bool TryParseMessage(in ReadOnlySequence<byte> input, ref SequencePosition consumed, ref SequencePosition examined, out int message)
+            {
+                if(input.IsEmpty)
+                {
+                    message = 0;
+                    return false;
+                }
+
+                // Move along in the set.
+                consumed = input.GetPosition(chunkSize);
+                examined = consumed;
+
+                message = chunkSize;
+
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Benchmark reading a stream consisting of chunks of pre-determined lengths of data.
+        /// </summary>
+        [Benchmark]
+        public async ValueTask ReadChunkedProtocol()
+        {
+            var writeMemory = dataPipe.Writer.GetMemory(ChunkSize * ChunkCount);
+            // Tell the pipe we've put all the required data in memory (we haven't).
+            dataPipe.Writer.Advance(ChunkSize * ChunkCount);
+            dataPipe.Writer.Complete();
+            
+            var reader = new ProtocolReader(dataPipe.Reader);
+#if DEBUG
+            int chunkCounts = 0;
+#endif
+            // Read the chunks.
+            while(!(await reader.ReadAsync(delimitedMessageReader)).IsCompleted)
+            {
+#if DEBUG
+                chunkCounts++;
+#endif
+                reader.Advance();
+            }
+
+#if DEBUG
+            if(chunkCounts != ChunkCount)
+            {
+                throw new ApplicationException("Didn't read all the chunks");
+            }
+#endif
+            dataPipe.Reader.Complete();
+
+            // Reset the pipe back to 0.
+            dataPipe.Reset();
+        }
+    }
+}


### PR DESCRIPTION
In these changes I've:

- Added a Bedrock.Framework.Benchmarks console project
- Configured an artifacts path with timestamped folders.
- Added the MemoryDiagnoser.
- Defined a benchmark class, ``ProtocolReaderBenchmarks``
- Added three benchmarks to that class:
   - PipeOnly - This is a baseline benchmark to determine the cost of only doing pipe write and read (without Bedrock). 
   - ReadProtocolWithWholeMessageAvailable - A benchmark for when the entire message is available (so the ``ProtocolReader.ReadAsync`` can just return immediately).
   - ReadProtocolWithPartialMessageAvailable - A benchmark for when the entire message is not available, and the ``ReadAsync`` method must go round again.

The ProtocolReader benchmarks do the absolute bare minimum of message reading work with a local ``IMessageReader`` implementation that just moves the positions along and returns whether the whole expected size is available.

Fixes #23.

Local Results:
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
AMD Ryzen 5 2500U with Radeon Vega Mobile Gfx, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.100
  [Host]     : .NET Core 3.1.0 (CoreCLR 4.700.19.56402, CoreFX 4.700.19.56404), X64 RyuJIT
  DefaultJob : .NET Core 3.1.0 (CoreCLR 4.700.19.56402, CoreFX 4.700.19.56404), X64 RyuJIT


```
|                                  Method | MessageSize |     Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------------------------- |------------ |---------:|---------:|---------:|------:|--------:|------:|------:|------:|----------:|
|                                **PipeOnly** |          **10** | **405.6 ns** |  **4.05 ns** |  **3.59 ns** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
|   ReadProtocolWithWholeMessageAvailable |          10 | 476.9 ns |  8.72 ns |  8.15 ns |  1.17 |    0.02 |     - |     - |     - |         - |
| ReadProtocolWithPartialMessageAvailable |          10 | 622.6 ns |  9.74 ns |  9.11 ns |  1.54 |    0.03 |     - |     - |     - |         - |
|                                         |             |          |          |          |       |         |       |       |       |           |
|                                **PipeOnly** |         **100** | **404.5 ns** |  **4.29 ns** |  **4.01 ns** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
|   ReadProtocolWithWholeMessageAvailable |         100 | 486.5 ns |  8.34 ns |  7.80 ns |  1.20 |    0.02 |     - |     - |     - |         - |
| ReadProtocolWithPartialMessageAvailable |         100 | 629.4 ns |  9.36 ns |  8.75 ns |  1.56 |    0.03 |     - |     - |     - |         - |
|                                         |             |          |          |          |       |         |       |       |       |           |
|                                **PipeOnly** |        **1000** | **438.1 ns** |  **5.05 ns** |  **4.72 ns** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
|   ReadProtocolWithWholeMessageAvailable |        1000 | 582.3 ns | 11.46 ns | 16.44 ns |  1.35 |    0.03 |     - |     - |     - |         - |
| ReadProtocolWithPartialMessageAvailable |        1000 | 734.9 ns | 12.15 ns | 10.77 ns |  1.68 |    0.03 |     - |     - |     - |         - |
