### PR TITLE
TLS internal infra

### DIFF
--- a/src/Bedrock.Framework.Experimental/Infrastructure/Endianness.cs
+++ b/src/Bedrock.Framework.Experimental/Infrastructure/Endianness.cs
@@ -20,9 +20,9 @@ namespace Bedrock.Framework.Experimental.Infrastructure
             return value;
         }
 
-        public static unsafe T Reverse<T>(T value) where T : unmanaged
+        public static T Reverse<T>(T value) where T : unmanaged
         {
-            var len = sizeof(T);
+            var len = Unsafe.SizeOf<T>();
             if (len == 1)
             {
                 return value;
@@ -30,37 +30,24 @@ namespace Bedrock.Framework.Experimental.Infrastructure
             else if (len == 2)
             {
                 var val = BinaryPrimitives.ReverseEndianness(Unsafe.As<T, ushort>(ref value));
-                return Unsafe.Read<T>(&val);
+                return Unsafe.As<ushort, T>(ref val);
             }
             else if (len == 4)
             {
                 var val = BinaryPrimitives.ReverseEndianness(Unsafe.As<T, uint>(ref value));
-                return Unsafe.Read<T>(&val);
+                return Unsafe.As<uint, T>(ref val);
             }
             else if (len == 8)
             {
                 var val = BinaryPrimitives.ReverseEndianness(Unsafe.As<T, ulong>(ref value));
-                return Unsafe.Read<T>(&val);
+                return Unsafe.As<ulong, T>(ref val);
             }
             else if (len < 512)
             {
-                var val = stackalloc byte[len];
-                Unsafe.Write(val, value);
-                int to = len >> 1, dest = len - 1;
-                for (var i = 0; i < to; i++)
+                unsafe
                 {
-                    var tmp = val[i];
-                    val[i] = val[dest];
-                    val[dest--] = tmp;
-                }
-                return Unsafe.Read<T>(val);
-            }
-            else
-            {
-                var val = new byte[len];
-                fixed (void* valPointer = val)
-                {
-                    Unsafe.Write(valPointer, value);
+                    var val = stackalloc byte[len];
+                    Unsafe.Write(val, value);
                     int to = len >> 1, dest = len - 1;
                     for (var i = 0; i < to; i++)
                     {
@@ -68,8 +55,27 @@ namespace Bedrock.Framework.Experimental.Infrastructure
                         val[i] = val[dest];
                         val[dest--] = tmp;
                     }
+                    return Unsafe.Read<T>(val);
+                }
+            }
+            else
+            {
+                var val = new byte[len];
+                unsafe
+                {
+                    fixed (void* valPointer = val)
+                    {
+                        Unsafe.Write(valPointer, value);
+                        int to = len >> 1, dest = len - 1;
+                        for (var i = 0; i < to; i++)
+                        {
+                            var tmp = val[i];
+                            val[i] = val[dest];
+                            val[dest--] = tmp;
+                        }
 
-                    return Unsafe.Read<T>(valPointer);
+                        return Unsafe.Read<T>(valPointer);
+                    }
                 }
             }
         }

--- a/src/Bedrock.Framework.Experimental/Infrastructure/Endianness.cs
+++ b/src/Bedrock.Framework.Experimental/Infrastructure/Endianness.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -28,30 +29,17 @@ namespace Bedrock.Framework.Experimental.Infrastructure
             }
             else if (len == 2)
             {
-                var val = Unsafe.Read<ushort>(&value);
-                val = (ushort)((val >> 8) | (val << 8));
+                var val = BinaryPrimitives.ReverseEndianness(Unsafe.As<T, ushort>(ref value));
                 return Unsafe.Read<T>(&val);
             }
             else if (len == 4)
             {
-                var val = Unsafe.Read<uint>(&value);
-                val = (val << 24)
-                    | ((val & 0xFF00) << 8)
-                    | ((val & 0xFF0000) >> 8)
-                    | (val >> 24);
+                var val = BinaryPrimitives.ReverseEndianness(Unsafe.As<T, uint>(ref value));
                 return Unsafe.Read<T>(&val);
             }
             else if (len == 8)
             {
-                var val = Unsafe.Read<ulong>(&value);
-                val = (val << 56)
-                    | ((val & 0xFF00) << 40)
-                    | ((val & 0xFF0000) << 24)
-                    | ((val & 0xFF000000) << 8)
-                    | ((val & 0xFF00000000) >> 8)
-                    | ((val & 0xFF0000000000) >> 24)
-                    | ((val & 0xFF000000000000) >> 40)
-                    | (val >> 56);
+                var val = BinaryPrimitives.ReverseEndianness(Unsafe.As<T, ulong>(ref value));
                 return Unsafe.Read<T>(&val);
             }
             else if (len < 512)

--- a/src/Bedrock.Framework.Experimental/Infrastructure/Endianness.cs
+++ b/src/Bedrock.Framework.Experimental/Infrastructure/Endianness.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Bedrock.Framework.Experimental.Infrastructure
+{
+    public static class Endianness
+    {
+        public static unsafe T FromNetworkOrder<T>(T value) where T : unmanaged
+        {
+            if (BitConverter.IsLittleEndian) return Reverse(value);
+            return value;
+        }
+
+        public static unsafe T ToNetworkOrder<T>(T value) where T : unmanaged
+        {
+            if (BitConverter.IsLittleEndian) return Reverse(value);
+            return value;
+        }
+
+        public static unsafe T Reverse<T>(T value) where T : unmanaged
+        {
+            var len = sizeof(T);
+            if (len == 1)
+            {
+                return value;
+            }
+            else if (len == 2)
+            {
+                var val = Unsafe.Read<ushort>(&value);
+                val = (ushort)((val >> 8) | (val << 8));
+                return Unsafe.Read<T>(&val);
+            }
+            else if (len == 4)
+            {
+                var val = Unsafe.Read<uint>(&value);
+                val = (val << 24)
+                    | ((val & 0xFF00) << 8)
+                    | ((val & 0xFF0000) >> 8)
+                    | (val >> 24);
+                return Unsafe.Read<T>(&val);
+            }
+            else if (len == 8)
+            {
+                var val = Unsafe.Read<ulong>(&value);
+                val = (val << 56)
+                    | ((val & 0xFF00) << 40)
+                    | ((val & 0xFF0000) << 24)
+                    | ((val & 0xFF000000) << 8)
+                    | ((val & 0xFF00000000) >> 8)
+                    | ((val & 0xFF0000000000) >> 24)
+                    | ((val & 0xFF000000000000) >> 40)
+                    | (val >> 56);
+                return Unsafe.Read<T>(&val);
+            }
+            else if (len < 512)
+            {
+                var val = stackalloc byte[len];
+                Unsafe.Write(val, value);
+                int to = len >> 1, dest = len - 1;
+                for (var i = 0; i < to; i++)
+                {
+                    var tmp = val[i];
+                    val[i] = val[dest];
+                    val[dest--] = tmp;
+                }
+                return Unsafe.Read<T>(val);
+            }
+            else
+            {
+                var val = new byte[len];
+                fixed (void* valPointer = val)
+                {
+                    Unsafe.Write(valPointer, value);
+                    int to = len >> 1, dest = len - 1;
+                    for (var i = 0; i < to; i++)
+                    {
+                        var tmp = val[i];
+                        val[i] = val[dest];
+                        val[dest--] = tmp;
+                    }
+
+                    return Unsafe.Read<T>(valPointer);
+                }
+            }
+        }
+
+    }
+}

--- a/src/Bedrock.Framework.Experimental/Infrastructure/Endianness.cs
+++ b/src/Bedrock.Framework.Experimental/Infrastructure/Endianness.cs
@@ -20,34 +20,49 @@ namespace Bedrock.Framework.Experimental.Infrastructure
             return value;
         }
 
-        public static T Reverse<T>(T value) where T : unmanaged
+        public static unsafe T Reverse<T>(T value) where T : unmanaged
         {
-            var len = Unsafe.SizeOf<T>();
-            if (len == 1)
+            if (sizeof(T) == 1)
             {
                 return value;
             }
-            else if (len == 2)
+            else if (sizeof(T) == 2)
             {
                 var val = BinaryPrimitives.ReverseEndianness(Unsafe.As<T, ushort>(ref value));
                 return Unsafe.As<ushort, T>(ref val);
             }
-            else if (len == 4)
+            else if (sizeof(T) == 4)
             {
                 var val = BinaryPrimitives.ReverseEndianness(Unsafe.As<T, uint>(ref value));
                 return Unsafe.As<uint, T>(ref val);
             }
-            else if (len == 8)
+            else if (sizeof(T) == 8)
             {
                 var val = BinaryPrimitives.ReverseEndianness(Unsafe.As<T, ulong>(ref value));
                 return Unsafe.As<ulong, T>(ref val);
             }
-            else if (len < 512)
+            else if (sizeof(T) < 512)
             {
-                unsafe
+                var len = sizeof(T);
+                var val = stackalloc byte[len];
+                Unsafe.Write(val, value);
+                int to = len >> 1, dest = len - 1;
+                for (var i = 0; i < to; i++)
                 {
-                    var val = stackalloc byte[len];
-                    Unsafe.Write(val, value);
+                    var tmp = val[i];
+                    val[i] = val[dest];
+                    val[dest--] = tmp;
+                }
+                return Unsafe.Read<T>(val);
+            }
+            else
+            {
+                var len = sizeof(T);
+                var val = new byte[len];
+
+                fixed (void* valPointer = val)
+                {
+                    Unsafe.Write(valPointer, value);
                     int to = len >> 1, dest = len - 1;
                     for (var i = 0; i < to; i++)
                     {
@@ -55,30 +70,10 @@ namespace Bedrock.Framework.Experimental.Infrastructure
                         val[i] = val[dest];
                         val[dest--] = tmp;
                     }
-                    return Unsafe.Read<T>(val);
-                }
-            }
-            else
-            {
-                var val = new byte[len];
-                unsafe
-                {
-                    fixed (void* valPointer = val)
-                    {
-                        Unsafe.Write(valPointer, value);
-                        int to = len >> 1, dest = len - 1;
-                        for (var i = 0; i < to; i++)
-                        {
-                            var tmp = val[i];
-                            val[i] = val[dest];
-                            val[dest--] = tmp;
-                        }
 
-                        return Unsafe.Read<T>(valPointer);
-                    }
+                    return Unsafe.Read<T>(valPointer);
                 }
             }
         }
-
     }
 }

--- a/src/Bedrock.Framework.Experimental/Protocols/Tls/BulkCiphers/AdditionalInfo.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Tls/BulkCiphers/AdditionalInfo.cs
@@ -1,0 +1,21 @@
+﻿using Bedrock.Framework.Experimental.Infrastructure;
+using Bedrock.Framework.Experimental.Protocols.Tls.Records;
+using System.Net;
+using System.Runtime.InteropServices;
+
+namespace Bedrock.Framework.Experimental.Protocols.Tls.BulkCiphers
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    internal struct AdditionalInfo
+    {
+        private ulong _sequenceNumber;
+        private RecordType _recordType;
+        private TlsVersion _tlsVersion;
+        private ushort _plainTextLength;
+
+        public ulong SequenceNumber { get => Endianness.FromNetworkOrder(_sequenceNumber); set => _sequenceNumber = Endianness.ToNetworkOrder(value); }
+        public RecordType RecordType { get => _recordType; set => _recordType = value; }
+        public TlsVersion TlsVersion { get => Endianness.FromNetworkOrder(_tlsVersion); set => _tlsVersion = Endianness.ToNetworkOrder(value); }
+        public ushort PlainTextLength { get => Endianness.FromNetworkOrder(_plainTextLength); set => _plainTextLength = Endianness.ToNetworkOrder(value); }
+    }
+}

--- a/src/Bedrock.Framework.Experimental/Protocols/Tls/BulkCiphers/AeadBulkCipher.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Tls/BulkCiphers/AeadBulkCipher.cs
@@ -1,0 +1,64 @@
+﻿using Bedrock.Framework.Experimental.Protocols.Tls.Records;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Text;
+
+namespace Bedrock.Framework.Experimental.Protocols.Tls.BulkCiphers
+{
+    internal abstract class AeadBulkCipher : IDisposable
+    {
+        protected const int AdditionalInfoHeaderSize = 13;
+        protected ulong _sequenceNumber;
+        protected ISymmetricalCipher _key;
+
+        public int Overhead => _key.TagSize;
+
+        public abstract void Decrypt(ref ReadOnlySequence<byte> messageBuffer, PipeWriter writer, RecordType recordType, TlsVersion tlsVersion);
+        public abstract void Encrypt(ref PipeWriter writer, ReadOnlySequence<byte> plainText, RecordType recordType, TlsVersion tlsVersion);
+        public void SetKey(ISymmetricalCipher key) => _key = key;
+        public virtual void IncrementSequence() => _sequenceNumber++;
+
+        protected void WriteTag(ref PipeWriter writer)
+        {
+            var tagBuffer = writer.GetSpan(_key.TagSize);
+            _key.GetTag(tagBuffer.Slice(0, _key.TagSize));
+            writer.Advance(_key.TagSize);
+        }
+
+        protected void Decrypt(ref ReadOnlySequence<byte> messageBuffer, PipeWriter writer)
+        {
+            if (messageBuffer.IsSingleSegment)
+            {
+                var writeBuffer = writer.GetSpan(messageBuffer.FirstSpan.Length);
+                writer.Advance(_key.Finish(messageBuffer.FirstSpan, writeBuffer));
+                IncrementSequence();
+                return;
+            }
+            var bytesRemaining = messageBuffer.Length;
+            foreach (var b in messageBuffer)
+            {
+                if (b.Length == 0) continue;
+                var writeBuffer = writer.GetSpan(b.Length);
+                bytesRemaining -= b.Length;
+                if (bytesRemaining == 0)
+                {
+                    writer.Advance(_key.Finish(b.Span, writeBuffer));
+                    break;
+                }
+                writer.Advance(_key.Update(b.Span,writeBuffer));
+            }
+            IncrementSequence();
+        }
+
+        public void Dispose()
+        {
+            _key?.Dispose();
+            _key = null;
+            GC.SuppressFinalize(this);
+        }
+
+        ~AeadBulkCipher() => Dispose();
+    }
+}

--- a/src/Bedrock.Framework.Experimental/Protocols/Tls/BulkCiphers/BulkCipherType.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Tls/BulkCiphers/BulkCipherType.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Bedrock.Framework.Experimental.Protocols.Tls.BulkCiphers
+{
+    internal enum BulkCipherType
+    {
+        AES_128_GCM,
+        AES_256_GCM,
+        CHACHA20_POLY1305,
+        AES_128_CCM,
+        AES_128_CCM_8,
+    }
+}

--- a/src/Bedrock.Framework.Experimental/Protocols/Tls/BulkCiphers/IBulkCipherKeyProvider.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Tls/BulkCiphers/IBulkCipherKeyProvider.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Bedrock.Framework.Experimental.Protocols.Tls.BulkCiphers
+{
+    internal interface IBulkCipherKeyProvider : IDisposable
+    {
+        T GetCipher<T>(BulkCipherType cipherType, ReadOnlyMemory<byte> keyStorage) where T : AeadBulkCipher, new();
+        ISymmetricalCipher GetCipherKey(BulkCipherType cipherType, ReadOnlyMemory<byte> keyStorage);
+        (int keySize, int ivSize) GetCipherSize(BulkCipherType cipherType);
+    }
+}

--- a/src/Bedrock.Framework.Experimental/Protocols/Tls/BulkCiphers/ISymmertricalCipher.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Tls/BulkCiphers/ISymmertricalCipher.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Bedrock.Framework.Experimental.Protocols.Tls.BulkCiphers
+{
+    internal interface ISymmertricalCipher : IDisposable
+    {
+        Memory<byte> IV { get; }
+        int TagSize { get; }
+        void Init(KeyMode mode);
+        int Update(ReadOnlySpan<byte> input, Span<byte> output);
+        int Update(Span<byte> inOutput);
+        int Finish(Span<byte> inOuput);
+        int Finish(ReadOnlySpan<byte> input, Span<byte> output);
+        void AddAdditionalInfo(in AdditionalInfo addInfo);
+        void GetTag(Span<byte> tagOutput);
+        void SetTag(ReadOnlySpan<byte> tagInput);
+    }
+}

--- a/src/Bedrock.Framework.Experimental/Protocols/Tls/BulkCiphers/ISymmetricalCipher.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Tls/BulkCiphers/ISymmetricalCipher.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Bedrock.Framework.Experimental.Protocols.Tls.BulkCiphers
 {
-    internal interface ISymmertricalCipher : IDisposable
+    internal interface ISymmetricalCipher : IDisposable
     {
         Memory<byte> IV { get; }
         int TagSize { get; }

--- a/src/Bedrock.Framework.Experimental/Protocols/Tls/BulkCiphers/KeyMode.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Tls/BulkCiphers/KeyMode.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Bedrock.Framework.Experimental.Protocols.Tls.BulkCiphers
+{
+    internal enum KeyMode
+    {
+        Encryption = 1,
+        Decryption = 0,
+    }
+}

--- a/src/Bedrock.Framework.Experimental/Protocols/Tls/Records/RecordType.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Tls/Records/RecordType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Bedrock.Framework.Experimental.Protocols.Tls.Records
+{
+    internal enum RecordType : byte
+    {
+        ChangeCipherSpec = 0x14,
+        Alert = 0x15,
+        Handshake = 0x16,
+        Application = 0x17,
+    }
+}

--- a/src/Bedrock.Framework.Experimental/Protocols/Tls/TlsVersion.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Tls/TlsVersion.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Bedrock.Framework.Experimental.Protocols.Tls
+{
+    public enum TlsVersion
+    {
+        Tls1 = 0x0301,
+        Tls11 = 0x0302,
+        Tls12 = 0x0303,
+        Tls13 = 0x0304,
+    }
+}


### PR DESCRIPTION
This adds a few things

1. Some basic Enums for Tls versions/ record types etc
2. A Util to help out with reversing stuff for network byte order etc (thanks Ben for helping out)
3. The basic types needed to abstract out the "Bulk Ciphers (TLS RFC term or Symmetric ciphers as they would normally be known)

So this allows you to implement the ciphers in OpenSSL or BCrypt (Windows) etc without being tied to the implementation.

