### PR TITLE
Feature/consumable array buffer writer pooling

### DIFF
--- a/src/Bedrock.Framework/Protocols/ConsumableArrayBufferWriter.cs
+++ b/src/Bedrock.Framework/Protocols/ConsumableArrayBufferWriter.cs
@@ -128,6 +128,12 @@ namespace Bedrock.Framework.Protocols
             {
                 _index = 0;
                 _consumedCount = 0;
+                if (Capacity >= DefaultInitialBufferSize * 2)
+                {
+                    // No point holding on to a large buffer
+                    ArrayPool<byte>.Shared.Return(_buffer);
+                    _buffer = Array.Empty<byte>();
+                }
             }
             else
             {

--- a/src/Bedrock.Framework/Protocols/ConsumableArrayBufferWriter.cs
+++ b/src/Bedrock.Framework/Protocols/ConsumableArrayBufferWriter.cs
@@ -4,27 +4,27 @@ using System.Diagnostics;
 
 namespace Bedrock.Framework.Protocols
 {
-    internal class ConsumableArrayBufferWriter<T> : IBufferWriter<T>, IDisposable
+    internal class ConsumableArrayBufferWriter : IBufferWriter<byte>, IDisposable
     {
-        private T[] _buffer;
+        private byte[] _buffer;
         private int _index;
         private int _consumedCount;
 
         private const int DefaultInitialBufferSize = 256;
 
         /// <summary>
-        /// Creates an instance of an <see cref="ConsumableArrayBufferWriter{T}"/>, in which data can be written to,
+        /// Creates an instance of an <see cref="ConsumableArrayBufferWriter{byte}"/>, in which data can be written to,
         /// with the default initial capacity.
         /// </summary>
         public ConsumableArrayBufferWriter()
         {
-            _buffer = Array.Empty<T>();
+            _buffer = Array.Empty<byte>();
             _index = 0;
             _consumedCount = 0;
         }
 
         /// <summary>
-        /// Creates an instance of an <see cref="ConsumableArrayBufferWriter{T}"/>, in which data can be written to,
+        /// Creates an instance of an <see cref="ConsumableArrayBufferWriter{byte}"/>, in which data can be written to,
         /// with an initial capacity specified.
         /// </summary>
         /// <param name="initialCapacity">The minimum capacity with which to initialize the underlying buffer.</param>
@@ -36,20 +36,20 @@ namespace Bedrock.Framework.Protocols
             if (initialCapacity <= 0)
                 throw new ArgumentException(nameof(initialCapacity));
 
-            _buffer = ArrayPool<T>.Shared.Rent(initialCapacity);
+            _buffer = ArrayPool<byte>.Shared.Rent(initialCapacity);
             _index = 0;
             _consumedCount = 0;
         }
 
         /// <summary>
-        /// Returns the unconsumed data written to the underlying buffer so far, as a <see cref="ReadOnlyMemory{T}"/>.
+        /// Returns the unconsumed data written to the underlying buffer so far, as a <see cref="ReadOnlyMemory{byte}"/>.
         /// </summary>
-        public ReadOnlyMemory<T> WrittenMemory => _buffer.AsMemory(_consumedCount.._index);
+        public ReadOnlyMemory<byte> WrittenMemory => _buffer.AsMemory(_consumedCount.._index);
 
         /// <summary>
-        /// Returns the unconsumed data written to the underlying buffer so far, as a <see cref="ReadOnlySpan{T}"/>.
+        /// Returns the unconsumed data written to the underlying buffer so far, as a <see cref="ReadOnlySpan{byte}"/>.
         /// </summary>
-        public ReadOnlySpan<T> WrittenSpan => _buffer.AsSpan(_consumedCount.._index);
+        public ReadOnlySpan<byte> WrittenSpan => _buffer.AsSpan(_consumedCount.._index);
 
         /// <summary>
         /// Returns the amount of unconsumed data written to the underlying buffer so far.
@@ -70,7 +70,7 @@ namespace Bedrock.Framework.Protocols
         /// Clears the data written to the underlying buffer.
         /// </summary>
         /// <remarks>
-        /// You must clear the <see cref="ConsumedArrayBufferWriter{T}"/> before trying to re-use it.
+        /// You must clear the <see cref="ConsumedArrayBufferWriter{byte}"/> before trying to re-use it.
         /// </remarks>
         public void Clear()
         {
@@ -81,7 +81,7 @@ namespace Bedrock.Framework.Protocols
         }
 
         /// <summary>
-        /// Notifies <see cref="IBufferWriter{T}"/> that <paramref name="count"/> amount of data was written to the output <see cref="Span{T}"/>/<see cref="Memory{T}"/>
+        /// Notifies <see cref="IBufferWriter{byte}"/> that <paramref name="count"/> amount of data was written to the output <see cref="Span{byte}"/>/<see cref="Memory{byte}"/>
         /// </summary>
         /// <exception cref="ArgumentException">
         /// Thrown when <paramref name="count"/> is negative.
@@ -104,7 +104,7 @@ namespace Bedrock.Framework.Protocols
         }
 
         /// <summary>
-        /// Notifies <see cref="ConsumableArrayBufferWriter{T}"/> that <paramref name="count"/> amount of data was consumed from the output <see cref="Span{T}"/>/<see cref="Memory{T}"/ and can be overwritten>
+        /// Notifies <see cref="ConsumableArrayBufferWriter{byte}"/> that <paramref name="count"/> amount of data was consumed from the output <see cref="Span{byte}"/>/<see cref="Memory{byte}"/ and can be overwritten>
         /// </summary>
         /// <exception cref="ArgumentException">
         /// Thrown when <paramref name="count"/> is negative.
@@ -136,14 +136,14 @@ namespace Bedrock.Framework.Protocols
         }
 
         /// <summary>
-        /// Returns a <see cref="Memory{T}"/> to write to that is at least the requested length (specified by <paramref name="sizeHint"/>).
+        /// Returns a <see cref="Memory{byte}"/> to write to that is at least the requested length (specified by <paramref name="sizeHint"/>).
         /// If no <paramref name="sizeHint"/> is provided (or it's equal to <code>0</code>), some non-empty buffer is returned.
         /// </summary>
         /// <exception cref="ArgumentException">
         /// Thrown when <paramref name="sizeHint"/> is negative.
         /// </exception>
         /// <remarks>
-        /// This will never return an empty <see cref="Memory{T}"/>.
+        /// This will never return an empty <see cref="Memory{byte}"/>.
         /// </remarks>
         /// <remarks>
         /// There is no guarantee that successive calls will return the same buffer or the same-sized buffer.
@@ -151,7 +151,7 @@ namespace Bedrock.Framework.Protocols
         /// <remarks>
         /// You must request a new buffer after calling Advance to continue writing more data and cannot write to a previously acquired buffer.
         /// </remarks>
-        public Memory<T> GetMemory(int sizeHint = 0)
+        public Memory<byte> GetMemory(int sizeHint = 0)
         {
             CheckAndResizeBuffer(sizeHint);
             Debug.Assert(_buffer.Length > _index);
@@ -159,14 +159,14 @@ namespace Bedrock.Framework.Protocols
         }
 
         /// <summary>
-        /// Returns a <see cref="Span{T}"/> to write to that is at least the requested length (specified by <paramref name="sizeHint"/>).
+        /// Returns a <see cref="Span{byte}"/> to write to that is at least the requested length (specified by <paramref name="sizeHint"/>).
         /// If no <paramref name="sizeHint"/> is provided (or it's equal to <code>0</code>), some non-empty buffer is returned.
         /// </summary>
         /// <exception cref="ArgumentException">
         /// Thrown when <paramref name="sizeHint"/> is negative.
         /// </exception>
         /// <remarks>
-        /// This will never return an empty <see cref="Span{T}"/>.
+        /// This will never return an empty <see cref="Span{byte}"/>.
         /// </remarks>
         /// <remarks>
         /// There is no guarantee that successive calls will return the same buffer or the same-sized buffer.
@@ -174,7 +174,7 @@ namespace Bedrock.Framework.Protocols
         /// <remarks>
         /// You must request a new buffer after calling Advance to continue writing more data and cannot write to a previously acquired buffer.
         /// </remarks>
-        public Span<T> GetSpan(int sizeHint = 0)
+        public Span<byte> GetSpan(int sizeHint = 0)
         {
             CheckAndResizeBuffer(sizeHint);
             Debug.Assert(_buffer.Length > _index);
@@ -212,7 +212,7 @@ namespace Bedrock.Framework.Protocols
                     }
 
                     var newSize = checked(_buffer.Length + growBy);
-                    var destinationArray = ArrayPool<T>.Shared.Rent(newSize);
+                    var destinationArray = ArrayPool<byte>.Shared.Rent(newSize);
                     Array.Copy(_buffer, _consumedCount, destinationArray, 0, countUnconsumed);
                     ReturnBuffer();
                     _buffer = destinationArray;
@@ -232,10 +232,7 @@ namespace Bedrock.Framework.Protocols
 
         private void ReturnBuffer()
         {
-            // We only need to clear the array if the type can contain any reference types.
-            // For now we only actually use this with byte, so we'll special case it.
-            // Since the JIT will remove this check, if we make this public we can add as many value types as we want.
-            ArrayPool<T>.Shared.Return(_buffer, clearArray: typeof(T) != typeof(byte));
+            ArrayPool<byte>.Shared.Return(_buffer);
         }
     }
 }

--- a/src/Bedrock.Framework/Protocols/MessagePipeReader.cs
+++ b/src/Bedrock.Framework/Protocols/MessagePipeReader.cs
@@ -18,7 +18,7 @@ namespace Bedrock.Framework.Protocols
         private bool _isThisCompleted;
         private bool _isCanceled;
         private bool _isCompleted;
-        private ConsumableArrayBufferWriter<byte> _backlog = new ConsumableArrayBufferWriter<byte>();
+        private readonly ConsumableArrayBufferWriter<byte> _backlog = new ConsumableArrayBufferWriter<byte>();
         private bool _allExamined;
         private bool _advanced = true;
         public MessagePipeReader(PipeReader reader, IMessageReader<ReadOnlySequence<byte>> messageReader)
@@ -80,7 +80,7 @@ namespace Bedrock.Framework.Protocols
                 _reader.AdvanceTo(_consumed, _examined);
             }
             _isThisCompleted = true;
-            _backlog = null;
+            _backlog.Dispose();
         }
 
         public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)

--- a/src/Bedrock.Framework/Protocols/MessagePipeReader.cs
+++ b/src/Bedrock.Framework/Protocols/MessagePipeReader.cs
@@ -18,7 +18,7 @@ namespace Bedrock.Framework.Protocols
         private bool _isThisCompleted;
         private bool _isCanceled;
         private bool _isCompleted;
-        private readonly ConsumableArrayBufferWriter<byte> _backlog = new ConsumableArrayBufferWriter<byte>();
+        private readonly ConsumableArrayBufferWriter _backlog = new ConsumableArrayBufferWriter();
         private bool _allExamined;
         private bool _advanced = true;
         public MessagePipeReader(PipeReader reader, IMessageReader<ReadOnlySequence<byte>> messageReader)

--- a/tests/Bedrock.Framework.Tests/ConsumableArrayBufferWriterTests.cs
+++ b/tests/Bedrock.Framework.Tests/ConsumableArrayBufferWriterTests.cs
@@ -39,16 +39,40 @@ namespace Bedrock.Framework.Tests
         }
 
         [Fact]
-        public void IfConsumedEqualsWrittenFreeCapacityIsReset()
+        public void IfConsumedEqualsWritten_AndCapacityIsSmall_FreeCapacityIsReset()
         {
-            var output = new ConsumableArrayBufferWriter(256);
-            Assert.Equal(256, output.FreeCapacity);
+            ConsumableArrayBufferWriter output;
+            do
+            {
+                output = new ConsumableArrayBufferWriter(256);
+            }
+            while (output.Capacity >= 512);
+
+            var capacity = output.Capacity;
+            Assert.InRange(capacity, 256, 512);
+            Assert.Equal(capacity, output.FreeCapacity);
             WriteData(output, 128);
-            Assert.Equal(128, output.FreeCapacity);
+            Assert.Equal(capacity - 128, output.FreeCapacity);
             output.Consume(64);
-            Assert.Equal(128, output.FreeCapacity);
+            Assert.Equal(capacity - 128, output.FreeCapacity);
             output.Consume(64);
-            Assert.Equal(256, output.FreeCapacity);
+            Assert.Equal(capacity, output.FreeCapacity);
+        }
+
+        [Fact]
+        public void IfConsumedEqualsWritten_AndCapacityIsLarge_BackingArrayIsReturned()
+        {
+            var output = new ConsumableArrayBufferWriter(512);
+            var capacity = output.Capacity;
+            Assert.InRange(capacity, 512, int.MaxValue);
+            Assert.Equal(capacity, output.FreeCapacity);
+            WriteData(output, 128);
+            Assert.Equal(capacity - 128, output.FreeCapacity);
+            output.Consume(64);
+            Assert.Equal(capacity - 128, output.FreeCapacity);
+            output.Consume(64);
+            Assert.Equal(0, output.Capacity);
+            Assert.Equal(0, output.FreeCapacity);
         }
 
         [Fact]

--- a/tests/Bedrock.Framework.Tests/ConsumableArrayBufferWriterTests.cs
+++ b/tests/Bedrock.Framework.Tests/ConsumableArrayBufferWriterTests.cs
@@ -85,42 +85,39 @@ namespace Bedrock.Framework.Tests
         public void CapacityDoesNotIncreaseIfThereIsPlentyOfConsumedSpace()
         {
             var output = new ConsumableArrayBufferWriter<T>(256);
-            WriteData(output, 256);
-            output.Consume(156);
+            var capacity = output.Capacity;
+            WriteData(output, capacity);
+            output.Consume(capacity - 100);
             var data = output.WrittenSpan.ToArray();
             output.GetMemory(16);
-            Assert.Equal(256, output.Capacity);
+            Assert.Equal(capacity, output.Capacity);
             Assert.Equal(data, output.WrittenSpan.ToArray());
-            Assert.Equal(156, output.FreeCapacity);
+            Assert.Equal(capacity - 100, output.FreeCapacity);
             Assert.Equal(100, output.UnconsumedWrittenCount);
-        }
-
-        [Fact]
-        public void CapacityDoesIncreaseIfThereIsNotEnoughConsumedSpace()
-        {
-            var output = new ConsumableArrayBufferWriter<T>(256);
-            WriteData(output, 256);
-            output.Consume(16);
-            var data = output.WrittenSpan.ToArray();
-            output.GetMemory(32);
-            Assert.Equal(512, output.Capacity);
-            Assert.Equal(data, output.WrittenSpan.ToArray());
-            Assert.Equal(272, output.FreeCapacity);
-            Assert.Equal(240, output.UnconsumedWrittenCount);
         }
 
         [Fact]
         public void CapacityDoesIncreaseIfThereIsOnlyMinimalConsumedSpace()
         {
             var output = new ConsumableArrayBufferWriter<T>(256);
-            WriteData(output, 256);
+            var capacity = output.Capacity;
+            WriteData(output, capacity);
             output.Consume(100);
             var data = output.WrittenSpan.ToArray();
             output.GetMemory(16);
-            Assert.Equal(512, output.Capacity);
+            Assert.InRange(output.Capacity, capacity * 2, int.MaxValue);
             Assert.Equal(data, output.WrittenSpan.ToArray());
-            Assert.Equal(356, output.FreeCapacity);
-            Assert.Equal(156, output.UnconsumedWrittenCount);
+            Assert.Equal(capacity - 100, output.UnconsumedWrittenCount);
+        }
+
+        [Fact]
+        public void ThrowsIfUsedAfterDisposed()
+        {
+            var buffer = new ConsumableArrayBufferWriter<T>();
+            buffer.Dispose();
+            Assert.Throws<NullReferenceException>(() => buffer.Clear());
+            Assert.Throws<NullReferenceException>(() => buffer.GetMemory());
+            Assert.Throws<NullReferenceException>(() => buffer.GetSpan());
         }
 
         #region ArrayBufferWriterTests
@@ -273,7 +270,7 @@ namespace Bedrock.Framework.Tests
         {
             var output = new ConsumableArrayBufferWriter<T>();
             var span = output.GetSpan(sizeHint);
-            Assert.Equal(sizeHint <= 256 ? 256 : sizeHint, span.Length);
+            Assert.InRange(span.Length, sizeHint, int.MaxValue);
         }
 
         [Fact]
@@ -281,7 +278,7 @@ namespace Bedrock.Framework.Tests
         {
             var output = new ConsumableArrayBufferWriter<T>(100);
             var span = output.GetSpan();
-            Assert.Equal(100, span.Length);
+            Assert.InRange(span.Length, 100, int.MaxValue);
         }
 
         [Theory]
@@ -291,13 +288,13 @@ namespace Bedrock.Framework.Tests
             {
                 var output = new ConsumableArrayBufferWriter<T>(256);
                 var span = output.GetSpan(sizeHint);
-                Assert.Equal(sizeHint <= 256 ? 256 : sizeHint + 256, span.Length);
+                Assert.InRange(span.Length, sizeHint, int.MaxValue);
             }
 
             {
                 var output = new ConsumableArrayBufferWriter<T>(1000);
                 var span = output.GetSpan(sizeHint);
-                Assert.Equal(sizeHint <= 1000 ? 1000 : sizeHint + 1000, span.Length);
+                Assert.InRange(span.Length, sizeHint <= 1000 ? 1000 : sizeHint + 1000, int.MaxValue);
             }
         }
 
@@ -315,7 +312,7 @@ namespace Bedrock.Framework.Tests
         {
             var output = new ConsumableArrayBufferWriter<T>();
             var memory = output.GetMemory(sizeHint);
-            Assert.Equal(sizeHint <= 256 ? 256 : sizeHint, memory.Length);
+            Assert.InRange(memory.Length, sizeHint, int.MaxValue);
         }
 
         [Fact]
@@ -323,7 +320,7 @@ namespace Bedrock.Framework.Tests
         {
             var output = new ConsumableArrayBufferWriter<T>(100);
             var memory = output.GetMemory();
-            Assert.Equal(100, memory.Length);
+            Assert.InRange(memory.Length, 100, int.MaxValue);
         }
 
         [Theory]
@@ -333,13 +330,13 @@ namespace Bedrock.Framework.Tests
             {
                 var output = new ConsumableArrayBufferWriter<T>(256);
                 var memory = output.GetMemory(sizeHint);
-                Assert.Equal(sizeHint <= 256 ? 256 : sizeHint + 256, memory.Length);
+                Assert.InRange(memory.Length, sizeHint, int.MaxValue);
             }
 
             {
                 var output = new ConsumableArrayBufferWriter<T>(1000);
                 var memory = output.GetMemory(sizeHint);
-                Assert.Equal(sizeHint <= 1000 ? 1000 : sizeHint + 1000, memory.Length);
+                Assert.InRange(memory.Length, sizeHint <= 1000 ? 1000 : sizeHint + 1000, int.MaxValue);
             }
         }
 

--- a/tests/Bedrock.Framework.Tests/ConsumableArrayBufferWriterTests.cs
+++ b/tests/Bedrock.Framework.Tests/ConsumableArrayBufferWriterTests.cs
@@ -354,11 +354,6 @@ namespace Bedrock.Framework.Tests
                 Assert.True(span.Length > 0);
                 Assert.True(memorySpan.Length > 0);
                 Assert.Equal(span.Length, memorySpan.Length);
-                for (var i = 0; i < span.Length; i++)
-                {
-                    Assert.Equal(default, span[i]);
-                    Assert.Equal(default, memorySpan[i]);
-                }
             }
 
             {
@@ -367,34 +362,22 @@ namespace Bedrock.Framework.Tests
                 var writtenSoFarMemory = output.WrittenMemory;
                 var writtenSoFar = output.WrittenSpan;
                 Assert.True(writtenSoFarMemory.Span.SequenceEqual(writtenSoFar));
-                var previousAvailable = output.FreeCapacity;
                 var span = output.GetSpan(500);
                 Assert.True(span.Length >= 500);
                 Assert.True(output.FreeCapacity >= 500);
-                Assert.True(output.FreeCapacity > previousAvailable);
 
                 Assert.Equal(writtenSoFar.Length, output.UnconsumedWrittenCount);
-                Assert.False(writtenSoFar.SequenceEqual(span.Slice(0, output.UnconsumedWrittenCount)));
 
                 var memory = output.GetMemory();
                 var memorySpan = memory.Span;
                 Assert.True(span.Length >= 500);
                 Assert.True(memorySpan.Length >= 500);
                 Assert.Equal(span.Length, memorySpan.Length);
-                for (var i = 0; i < span.Length; i++)
-                {
-                    Assert.Equal(default, span[i]);
-                    Assert.Equal(default, memorySpan[i]);
-                }
 
                 memory = output.GetMemory(500);
                 memorySpan = memory.Span;
                 Assert.True(memorySpan.Length >= 500);
                 Assert.Equal(span.Length, memorySpan.Length);
-                for (var i = 0; i < memorySpan.Length; i++)
-                {
-                    Assert.Equal(default, memorySpan[i]);
-                }
             }
         }
 

--- a/tests/Bedrock.Framework.Tests/ConsumableArrayBufferWriterTests.cs
+++ b/tests/Bedrock.Framework.Tests/ConsumableArrayBufferWriterTests.cs
@@ -115,7 +115,6 @@ namespace Bedrock.Framework.Tests
         {
             var buffer = new ConsumableArrayBufferWriter<T>();
             buffer.Dispose();
-            Assert.Throws<NullReferenceException>(() => buffer.Clear());
             Assert.Throws<NullReferenceException>(() => buffer.GetMemory());
             Assert.Throws<NullReferenceException>(() => buffer.GetSpan());
         }


### PR DESCRIPTION
Initial implementation of pooling for ConsumableArrayBufferWriter.

Before:

|                               Method | MessageSize | NumIterations |      Mean |     Error |    StdDev | Ratio | RatioSD |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|------------------------------------- |------------ |--------------------- |----------:|----------:|----------:|------:|--------:|---------:|---------:|---------:|----------:|
|         BASELINE:  PipeReaderConsumeAllEachTime |        4096 |           100 |  80.66 us |  1.894 us |  2.776 us |  1.00 |    0.00 |        - |        - |        - |       1 B |
|  MessagePipeReaderConsumeAllEachTime |        4096 |           100 | 117.55 us |  1.714 us |  1.603 us |  1.47 |    0.05 |        - |        - |        - |     425 B |
| MessagePipeReaderConsumeNoneEachTime |        4096 |           100 | 509.39 us | 10.146 us | 13.193 us |  6.30 |    0.27 | 285.1563 | 285.1563 | 285.1563 | 1048834 B |

After:

|                               Method | MessageSize | NumIterations |      Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------------- |------------ |-------------- |----------:|---------:|---------:|------:|--------:|------:|------:|------:|----------:|
|         PipeReaderConsumeAllEachTime |        4096 |           100 |  80.60 us | 1.576 us | 2.406 us |  1.00 |    0.00 |     - |     - |     - |       1 B |
|  MessagePipeReaderConsumeAllEachTime |        4096 |           100 | 118.24 us | 2.357 us | 2.205 us |  1.47 |    0.05 |     - |     - |     - |     145 B |
| MessagePipeReaderConsumeNoneEachTime |        4096 |           100 | 162.39 us | 2.330 us | 2.180 us |  2.01 |    0.06 |     - |     - |     - |     415 B |


Upper bound on benefits of pooling without any synchronization or resizing:

|                               Method | MessageSize | NumIterations |      Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------------- |------------ |--------------------- |----------:|---------:|---------:|------:|--------:|------:|------:|------:|----------:|
| MessagePipeReaderConsumeNoneEachTime |        4096 |           100 | 148.69 us | 2.215 us | 2.072 us |  1.82 |    0.05 |     - |     - |     - |     113 B |

One issue with this approach is that it requires users to call Complete once they are done parsing. I don't know if this is considered part of the contract.

If not the _backlog will not be returned to the ArrayPool. One consequence of this is we might pool it long enough for it to go on gen2 heap, but then drop it, which could lead to more GC pressure. See [this](https://github.com/dotnet/runtime/issues/1917#issuecomment-575994507) comment by Stephen Toub.