### PR TITLE
Feature/nrt

### DIFF
--- a/src/Bedrock.Framework/Bedrock.Framework.csproj
+++ b/src/Bedrock.Framework/Bedrock.Framework.csproj
@@ -5,6 +5,7 @@
     <PackageDescription>High performance, low level networking APIs for building custom severs and clients.</PackageDescription>
     <Authors>David Fowler</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Bedrock.Framework/ConnectionContextWithDelegate.cs
+++ b/src/Bedrock.Framework/ConnectionContextWithDelegate.cs
@@ -12,8 +12,8 @@ namespace Bedrock.Framework
     internal class ConnectionContextWithDelegate : ConnectionContext
     {
         private readonly ConnectionContext _connection;
-        private readonly TaskCompletionSource<object> _executionTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-        private Task _middlewareTask;
+        private readonly TaskCompletionSource<object?> _executionTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private Task? _middlewareTask;
         private ConnectionDelegate _connectionDelegate;
 
         public ConnectionContextWithDelegate(ConnectionContext connection, ConnectionDelegate connectionDelegate)
@@ -100,7 +100,7 @@ namespace Bedrock.Framework
 
             _executionTcs.TrySetResult(null);
 
-            await _middlewareTask.ConfigureAwait(false);
+            await _middlewareTask!.ConfigureAwait(false);
         }
     }
 }

--- a/src/Bedrock.Framework/Hosting/ServerHostedServiceOptions.cs
+++ b/src/Bedrock.Framework/Hosting/ServerHostedServiceOptions.cs
@@ -6,6 +6,6 @@ namespace Bedrock.Framework
 {
     public class ServerHostedServiceOptions
     {
-        public ServerBuilder ServerBuilder { get; set; }
+        public ServerBuilder ServerBuilder { get; set; } = null!;
     }
 }

--- a/src/Bedrock.Framework/Infrastructure/DuplexPipeStream.cs
+++ b/src/Bedrock.Framework/Infrastructure/DuplexPipeStream.cs
@@ -85,7 +85,7 @@ namespace Bedrock.Framework.Infrastructure
             WriteAsync(buffer, offset, count).GetAwaiter().GetResult();
         }
 
-        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[]? buffer, int offset, int count, CancellationToken cancellationToken)
         {
             if (buffer != null)
             {
@@ -147,7 +147,7 @@ namespace Bedrock.Framework.Infrastructure
             }
         }
 
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object? state)
         {
             return TaskToApm.Begin(ReadAsync(buffer, offset, count), callback, state);
         }
@@ -157,7 +157,7 @@ namespace Bedrock.Framework.Infrastructure
             return TaskToApm.End<int>(asyncResult);
         }
 
-        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object? state)
         {
             return TaskToApm.Begin(WriteAsync(buffer, offset, count), callback, state);
         }

--- a/src/Bedrock.Framework/Infrastructure/MemoryPoolExtensions.cs
+++ b/src/Bedrock.Framework/Infrastructure/MemoryPoolExtensions.cs
@@ -12,7 +12,7 @@ namespace Bedrock.Framework.Infrastructure
         /// </summary>
         /// <param name="pool"></param>
         /// <returns></returns>
-        public static int GetMinimumSegmentSize(this MemoryPool<byte> pool)
+        public static int GetMinimumSegmentSize(this MemoryPool<byte>? pool)
         {
             if (pool == null)
             {
@@ -22,7 +22,7 @@ namespace Bedrock.Framework.Infrastructure
             return Math.Min(4096, pool.MaxBufferSize);
         }
 
-        public static int GetMinimumAllocSize(this MemoryPool<byte> pool)
+        public static int GetMinimumAllocSize(this MemoryPool<byte>? pool)
         {
             // 1/2 of a segment
             return pool.GetMinimumSegmentSize() / 2;

--- a/src/Bedrock.Framework/Infrastructure/TaskExtensions.cs
+++ b/src/Bedrock.Framework/Infrastructure/TaskExtensions.cs
@@ -10,12 +10,12 @@ namespace Bedrock.Framework
     {
         public static async Task<bool> WithCancellation(this Task task, CancellationToken cancellationToken)
         {
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             // This disposes the registration as soon as one of the tasks trigger
             using (cancellationToken.Register(state =>
             {
-                ((TaskCompletionSource<object>)state).TrySetResult(null);
+                ((TaskCompletionSource<object?>)state!).TrySetResult(null);
             },
             tcs))
             {

--- a/src/Bedrock.Framework/Infrastructure/TaskToApm.cs
+++ b/src/Bedrock.Framework/Infrastructure/TaskToApm.cs
@@ -12,7 +12,6 @@
 //     public int EndFoo(IAsyncResult asyncResult) =>
 //         TaskToApm.End<int>(asyncResult);
 
-#nullable enable
 using System.Diagnostics;
 
 namespace System.Threading.Tasks

--- a/src/Bedrock.Framework/Infrastructure/TimerAwaitable.cs
+++ b/src/Bedrock.Framework/Infrastructure/TimerAwaitable.cs
@@ -10,8 +10,8 @@ namespace Bedrock.Framework
 {
     internal class TimerAwaitable : IDisposable, ICriticalNotifyCompletion
     {
-        private Timer _timer;
-        private Action _callback;
+        private Timer? _timer;
+        private Action? _callback;
         private static readonly Action _callbackCompleted = () => { };
 
         private readonly TimeSpan _period;
@@ -40,7 +40,7 @@ namespace Bedrock.Framework
 
                     if (_timer == null)
                     {
-                        _timer = new Timer(state => ((TimerAwaitable)state).Tick(), this, _dueTime, _period);
+                        _timer = new Timer(state => ((TimerAwaitable)state!).Tick(), this, _dueTime, _period);
                     }
                 }
             }

--- a/src/Bedrock.Framework/Middleware/ConnectionBuilderExtensions.cs
+++ b/src/Bedrock.Framework/Middleware/ConnectionBuilderExtensions.cs
@@ -28,7 +28,7 @@ namespace Bedrock.Framework
         /// <returns>
         /// The <see cref="ListenOptions"/>.
         /// </returns>
-        public static TBuilder UseConnectionLogging<TBuilder>(this TBuilder builder, string loggerName) where TBuilder : IConnectionBuilder
+        public static TBuilder UseConnectionLogging<TBuilder>(this TBuilder builder, string? loggerName) where TBuilder : IConnectionBuilder
         {
             var loggerFactory = builder.ApplicationServices.GetRequiredService<ILoggerFactory>();
             var logger = loggerName == null ? loggerFactory.CreateLogger<LoggingConnectionMiddleware>() : loggerFactory.CreateLogger(loggerName);

--- a/src/Bedrock.Framework/Middleware/Internal/LoggingStream.cs
+++ b/src/Bedrock.Framework/Middleware/Internal/LoggingStream.cs
@@ -174,7 +174,7 @@ namespace Bedrock.Framework.Infrastructure
         }
 
         // The below APM methods call the underlying Read/WriteAsync methods which will still be logged.
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object? state)
         {
             return TaskToApm.Begin(ReadAsync(buffer, offset, count), callback, state);
         }
@@ -184,7 +184,7 @@ namespace Bedrock.Framework.Infrastructure
             return TaskToApm.End<int>(asyncResult);
         }
 
-        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object? state)
         {
             return TaskToApm.Begin(WriteAsync(buffer, offset, count), callback, state);
         }

--- a/src/Bedrock.Framework/Middleware/Tls/CertificateLoader.cs
+++ b/src/Bedrock.Framework/Middleware/Tls/CertificateLoader.cs
@@ -20,8 +20,8 @@ namespace Bedrock.Framework.Middleware.Tls
         {
             using (var store = new X509Store(storeName, storeLocation))
             {
-                X509Certificate2Collection storeCertificates = null;
-                X509Certificate2 foundCertificate = null;
+                X509Certificate2Collection? storeCertificates = null;
+                X509Certificate2? foundCertificate = null;
 
                 try
                 {
@@ -90,7 +90,7 @@ namespace Bedrock.Framework.Middleware.Tls
         internal static bool DoesCertificateHaveAnAccessiblePrivateKey(X509Certificate2 certificate)
             => certificate.HasPrivateKey;
 
-        private static void DisposeCertificates(X509Certificate2Collection certificates, X509Certificate2 except)
+        private static void DisposeCertificates(X509Certificate2Collection? certificates, X509Certificate2? except)
         {
             if (certificates != null)
             {

--- a/src/Bedrock.Framework/Middleware/Tls/ITlsConnectionFeature.cs
+++ b/src/Bedrock.Framework/Middleware/Tls/ITlsConnectionFeature.cs
@@ -12,12 +12,12 @@ namespace Bedrock.Framework.Middleware.Tls
         /// <summary>
         /// Synchronously retrieves the remote endpoint's certificate, if any.
         /// </summary>
-        X509Certificate2 RemoteCertificate { get; set; }
+        X509Certificate2? RemoteCertificate { get; set; }
 
         /// <summary>
         /// Asynchronously retrieves the remote endpoint's certificate, if any.
         /// </summary>
         /// <returns></returns>
-        Task<X509Certificate2> GetRemoteCertificateAsync(CancellationToken cancellationToken);
+        Task<X509Certificate2?> GetRemoteCertificateAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Bedrock.Framework/Middleware/Tls/TlsClientConnectionMiddleware.cs
+++ b/src/Bedrock.Framework/Middleware/Tls/TlsClientConnectionMiddleware.cs
@@ -19,8 +19,8 @@ namespace Bedrock.Framework.Middleware.Tls
     {
         private readonly ConnectionDelegate _next;
         private readonly TlsOptions _options;
-        private readonly ILogger _logger;
-        private readonly X509Certificate2 _certificate;
+        private readonly ILogger? _logger;
+        private readonly X509Certificate2? _certificate;
 
         public TlsClientConnectionMiddleware(ConnectionDelegate next, TlsOptions options, ILoggerFactory loggerFactory)
         {
@@ -67,7 +67,7 @@ namespace Bedrock.Framework.Middleware.Tls
                 leaveOpen: true
             );
 
-            SslDuplexPipe sslDuplexPipe = null;
+            SslDuplexPipe? sslDuplexPipe = null;
 
             if (_options.RemoteCertificateMode == RemoteCertificateMode.NoCertificate)
             {
@@ -185,7 +185,7 @@ namespace Bedrock.Framework.Middleware.Tls
             }
         }
 
-        private static X509Certificate2 ConvertToX509Certificate2(X509Certificate certificate)
+        private static X509Certificate2? ConvertToX509Certificate2(X509Certificate certificate)
         {
             if (certificate is null)
             {

--- a/src/Bedrock.Framework/Middleware/Tls/TlsConnectionFeature.cs
+++ b/src/Bedrock.Framework/Middleware/Tls/TlsConnectionFeature.cs
@@ -10,9 +10,9 @@ namespace Bedrock.Framework.Middleware.Tls
 {
     internal class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicationProtocolFeature, ITlsHandshakeFeature
     {
-        public X509Certificate2 LocalCertificate { get; set; }
+        public X509Certificate2? LocalCertificate { get; set; }
 
-        public X509Certificate2 RemoteCertificate { get; set; }
+        public X509Certificate2? RemoteCertificate { get; set; }
 
         public ReadOnlyMemory<byte> ApplicationProtocol { get; set; }
 
@@ -30,7 +30,7 @@ namespace Bedrock.Framework.Middleware.Tls
 
         public int KeyExchangeStrength { get; set; }
 
-        public Task<X509Certificate2> GetRemoteCertificateAsync(CancellationToken cancellationToken)
+        public Task<X509Certificate2?> GetRemoteCertificateAsync(CancellationToken cancellationToken)
         {
             return Task.FromResult(RemoteCertificate);
         }

--- a/src/Bedrock.Framework/Middleware/Tls/TlsOptions.cs
+++ b/src/Bedrock.Framework/Middleware/Tls/TlsOptions.cs
@@ -35,7 +35,7 @@ namespace Bedrock.Framework.Middleware.Tls
         /// If the certificate has an Extended Key Usage extension, the usages must include Server Authentication (OID 1.3.6.1.5.5.7.3.1).
         /// </para>
         /// </summary>
-        public X509Certificate2 LocalCertificate { get; set; }
+        public X509Certificate2? LocalCertificate { get; set; }
 
         /// <summary>
         /// <para>
@@ -46,7 +46,7 @@ namespace Bedrock.Framework.Middleware.Tls
         /// If the certificate has an Extended Key Usage extension, the usages must include Server Authentication (OID 1.3.6.1.5.5.7.3.1).
         /// </para>
         /// </summary>
-        public Func<ConnectionContext, string, X509Certificate2> LocalServerCertificateSelector { get; set; }
+        public Func<ConnectionContext, string, X509Certificate2>? LocalServerCertificateSelector { get; set; }
 
         /// <summary>
         /// Specifies the remote endpoint certificate requirements for a TLS connection. Defaults to <see cref="RemoteCertificateMode.RequireCertificate"/>.
@@ -57,7 +57,7 @@ namespace Bedrock.Framework.Middleware.Tls
         /// Specifies a callback for additional remote certificate validation that will be invoked during authentication. This will be ignored
         /// if <see cref="AllowAnyRemoteCertificate"/> is called after this callback is set.
         /// </summary>
-        public RemoteCertificateValidator RemoteCertificateValidation { get; set; }
+        public RemoteCertificateValidator? RemoteCertificateValidation { get; set; }
 
         /// <summary>
         /// Specifies allowable SSL protocols. Defaults to <see cref="SslProtocols.Tls12" /> and <see cref="SslProtocols.Tls11"/>.
@@ -81,13 +81,13 @@ namespace Bedrock.Framework.Middleware.Tls
         /// Provides direct configuration of the <see cref="SslServerAuthenticationOptions"/> on a per-connection basis.
         /// This is called after all of the other settings have already been applied.
         /// </summary>
-        public Action<ConnectionContext, SslServerAuthenticationOptions> OnAuthenticateAsServer { get; set; }
+        public Action<ConnectionContext, SslServerAuthenticationOptions>? OnAuthenticateAsServer { get; set; }
 
         /// <summary>
         /// Provides direct configuration of the <see cref="SslClientAuthenticationOptions"/> on a per-connection basis.
         /// This is called after all of the other settings have already been applied.
         /// </summary>
-        public Action<ConnectionContext, SslClientAuthenticationOptions> OnAuthenticateAsClient { get; set; }
+        public Action<ConnectionContext, SslClientAuthenticationOptions>? OnAuthenticateAsClient { get; set; }
 
         /// <summary>
         /// Specifies the maximum amount of time allowed for the TLS/SSL handshake. This must be positive and finite.

--- a/src/Bedrock.Framework/Middleware/Tls/TlsServerConnectionMiddleware.cs
+++ b/src/Bedrock.Framework/Middleware/Tls/TlsServerConnectionMiddleware.cs
@@ -35,21 +35,19 @@ namespace Bedrock.Framework.Middleware.Tls
             // capture the certificate now so it can't be switched after validation
             _certificate = options.LocalCertificate;
             _certificateSelector = options.LocalServerCertificateSelector;
-            if (_certificate == null && _certificateSelector == null)
+            if (_certificateSelector == null)
             {
-                throw new ArgumentException("Server certificate is required", nameof(options));
-            }
-
-            // If a selector is provided then ignore the cert, it may be a default cert.
-            if (_certificateSelector != null)
-            {
-                // SslStream doesn't allow both.
-                _certificate = null;
+                if (_certificate == null)
+                {
+                    throw new ArgumentException("Server certificate is required", nameof(options));
+                }
+                EnsureCertificateIsAllowedForServerAuth(_certificate);
             }
             else
             {
-                // _certificate can't be null because _certifiacteSelector is not
-                EnsureCertificateIsAllowedForServerAuth(_certificate!);
+                // If a selector is provided then ignore the cert, it may be a default cert.
+                // SslStream doesn't allow both.
+                _certificate = null;
             }
 
             _options = options;

--- a/src/Bedrock.Framework/Middleware/Tls/TlsServerConnectionMiddleware.cs
+++ b/src/Bedrock.Framework/Middleware/Tls/TlsServerConnectionMiddleware.cs
@@ -19,9 +19,9 @@ namespace Bedrock.Framework.Middleware.Tls
     {
         private readonly ConnectionDelegate _next;
         private readonly TlsOptions _options;
-        private readonly ILogger _logger;
-        private readonly X509Certificate2 _certificate;
-        private readonly Func<ConnectionContext, string, X509Certificate2> _certificateSelector;
+        private readonly ILogger? _logger;
+        private readonly X509Certificate2? _certificate;
+        private readonly Func<ConnectionContext, string, X509Certificate2>? _certificateSelector;
 
         public TlsServerConnectionMiddleware(ConnectionDelegate next, TlsOptions options, ILoggerFactory loggerFactory)
         {
@@ -48,7 +48,8 @@ namespace Bedrock.Framework.Middleware.Tls
             }
             else
             {
-                EnsureCertificateIsAllowedForServerAuth(_certificate);
+                // _certificate can't be null because _certifiacteSelector is not
+                EnsureCertificateIsAllowedForServerAuth(_certificate!);
             }
 
             _options = options;
@@ -83,7 +84,7 @@ namespace Bedrock.Framework.Middleware.Tls
                 leaveOpen: true
             );
 
-            SslDuplexPipe sslDuplexPipe = null;
+            SslDuplexPipe? sslDuplexPipe = null;
 
             if (_options.RemoteCertificateMode == RemoteCertificateMode.NoCertificate)
             {
@@ -137,7 +138,7 @@ namespace Bedrock.Framework.Middleware.Tls
                 try
                 {
                     // Adapt to the SslStream signature
-                    ServerCertificateSelectionCallback selector = null;
+                    ServerCertificateSelectionCallback? selector = null;
                     if (_certificateSelector != null)
                     {
                         selector = (sender, name) =>
@@ -222,7 +223,7 @@ namespace Bedrock.Framework.Middleware.Tls
             }
         }
 
-        private static X509Certificate2 ConvertToX509Certificate2(X509Certificate certificate)
+        private static X509Certificate2? ConvertToX509Certificate2(X509Certificate certificate)
         {
             if (certificate is null)
             {

--- a/src/Bedrock.Framework/Protocols/MessagePipeReader.cs
+++ b/src/Bedrock.Framework/Protocols/MessagePipeReader.cs
@@ -73,14 +73,14 @@ namespace Bedrock.Framework.Protocols
             _reader.CancelPendingRead();
         }
 
-        public override void Complete(Exception exception = null)
+        public override void Complete(Exception? exception = null)
         {
             if (!_advanced)
             {
                 _reader.AdvanceTo(_consumed, _examined);
             }
             _isThisCompleted = true;
-            _backlog = null;
+            _backlog = null!;
         }
 
         public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)

--- a/src/Bedrock.Framework/Protocols/ProtocolReadResult.cs
+++ b/src/Bedrock.Framework/Protocols/ProtocolReadResult.cs
@@ -1,14 +1,17 @@
-﻿namespace Bedrock.Framework.Protocols
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Bedrock.Framework.Protocols
 {
     public readonly struct ProtocolReadResult<TMessage>
     {
-        public ProtocolReadResult(TMessage message, bool isCanceled, bool isCompleted)
+        public ProtocolReadResult([AllowNull] TMessage message, bool isCanceled, bool isCompleted)
         {
             Message = message;
             IsCanceled = isCanceled;
             IsCompleted = isCompleted;
         }
 
+        [MaybeNull]
         public TMessage Message { get; }
         public bool IsCanceled { get; }
         public bool IsCompleted { get; }

--- a/src/Bedrock.Framework/Protocols/WebSockets/WebSocketHeader.cs
+++ b/src/Bedrock.Framework/Protocols/WebSockets/WebSocketHeader.cs
@@ -127,7 +127,7 @@ namespace Bedrock.Framework.Protocols.WebSockets
         /// </summary>	
         /// <param name="obj">The WebSocketHeader value to check against.</param>	
         /// <returns>True if equal, false otherwise.</returns>
-        public override bool Equals(object obj) =>
+        public override bool Equals(object? obj) =>
             obj is object
             && obj is WebSocketHeader
             && (WebSocketHeader)obj == this;

--- a/src/Bedrock.Framework/Server/EndPointBinding.cs
+++ b/src/Bedrock.Framework/Server/EndPointBinding.cs
@@ -26,7 +26,7 @@ namespace Bedrock.Framework
             yield return await ConnectionListenerFactory.BindAsync(EndPoint, cancellationToken);
         }
 
-        public override string ToString()
+        public override string? ToString()
         {
             return EndPoint?.ToString();
         }

--- a/src/Bedrock.Framework/Server/EndPointBinding.cs
+++ b/src/Bedrock.Framework/Server/EndPointBinding.cs
@@ -8,18 +8,17 @@ namespace Bedrock.Framework
 {
     public class EndPointBinding : ServerBinding
     {
-        private readonly ConnectionDelegate _application;
         public EndPointBinding(EndPoint endPoint, ConnectionDelegate application, IConnectionListenerFactory connectionListenerFactory)
         {
             EndPoint = endPoint;
-            _application = application;
+            Application = application;
             ConnectionListenerFactory = connectionListenerFactory;
         }
 
         private EndPoint EndPoint { get; }
         private IConnectionListenerFactory ConnectionListenerFactory { get; }
 
-        public override ConnectionDelegate Application => _application;
+        public override ConnectionDelegate Application { get; }
 
         public override async IAsyncEnumerable<IConnectionListener> BindAsync([EnumeratorCancellation]CancellationToken cancellationToken)
         {

--- a/src/Bedrock.Framework/Server/LocalHostBinding.cs
+++ b/src/Bedrock.Framework/Server/LocalHostBinding.cs
@@ -10,19 +10,17 @@ namespace Bedrock.Framework
 {
     public class LocalHostBinding : ServerBinding
     {
-        private readonly ConnectionDelegate _application;
-
         public LocalHostBinding(int port, ConnectionDelegate application, IConnectionListenerFactory connectionListenerFactory)
         {
             Port = port;
-            _application = application;
+            Application = application;
             ConnectionListenerFactory = connectionListenerFactory;
         }
 
         private int Port { get; }
         private IConnectionListenerFactory ConnectionListenerFactory { get; }
 
-        public override ConnectionDelegate Application => _application;
+        public override ConnectionDelegate Application { get; }
 
         public override async IAsyncEnumerable<IConnectionListener> BindAsync([EnumeratorCancellation]CancellationToken cancellationToken = default)
         {

--- a/src/Bedrock.Framework/Server/LocalHostBinding.cs
+++ b/src/Bedrock.Framework/Server/LocalHostBinding.cs
@@ -28,8 +28,8 @@ namespace Bedrock.Framework
         {
             var exceptions = new List<Exception>();
 
-            IConnectionListener ipv6Listener = null;
-            IConnectionListener ipv4Listener = null;
+            IConnectionListener? ipv6Listener = null;
+            IConnectionListener? ipv4Listener = null;
 
             try
             {

--- a/src/Bedrock.Framework/Server/Server.cs
+++ b/src/Bedrock.Framework/Server/Server.cs
@@ -14,7 +14,7 @@ namespace Bedrock.Framework
         private readonly ServerBuilder _builder;
         private readonly ILogger<Server> _logger;
         private readonly List<RunningListener> _listeners = new List<RunningListener>();
-        private readonly TaskCompletionSource<object> _shutdownTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object?> _shutdownTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly TimerAwaitable _timerAwaitable;
         private Task _timerTask = Task.CompletedTask;
 
@@ -92,7 +92,7 @@ namespace Bedrock.Framework
 
             for (int i = 0; i < _listeners.Count; i++)
             {
-                tasks[i] = _listeners[i].ExecutionTask;
+                tasks[i] = _listeners[i].ExecutionTask!;
             }
 
             var shutdownTask = Task.WhenAll(tasks);
@@ -133,7 +133,7 @@ namespace Bedrock.Framework
             }
 
             public IConnectionListener Listener { get; }
-            public Task ExecutionTask { get; private set; }
+            public Task? ExecutionTask { get; private set; }
 
             public void TickHeartbeat()
             {
@@ -242,7 +242,7 @@ namespace Bedrock.Framework
             }
 
 
-            private IDisposable BeginConnectionScope(ServerConnection connection)
+            private IDisposable? BeginConnectionScope(ServerConnection connection)
             {
                 if (_server._logger.IsEnabled(LogLevel.Critical))
                 {

--- a/src/Bedrock.Framework/Server/ServerBinding.cs
+++ b/src/Bedrock.Framework/Server/ServerBinding.cs
@@ -7,7 +7,7 @@ namespace Bedrock.Framework
 {
     public abstract class ServerBinding
     {
-        public virtual ConnectionDelegate Application { get; }
+        public virtual ConnectionDelegate Application { get; } = null!; // We should probably make this abstract - both implementations override it.
 
         public abstract IAsyncEnumerable<IConnectionListener> BindAsync(CancellationToken cancellationToken = default);
     }

--- a/src/Bedrock.Framework/Server/ServerBinding.cs
+++ b/src/Bedrock.Framework/Server/ServerBinding.cs
@@ -7,7 +7,7 @@ namespace Bedrock.Framework
 {
     public abstract class ServerBinding
     {
-        public virtual ConnectionDelegate Application { get; } = null!; // We should probably make this abstract - both implementations override it.
+        public abstract ConnectionDelegate Application { get; }
 
         public abstract IAsyncEnumerable<IConnectionListener> BindAsync(CancellationToken cancellationToken = default);
     }

--- a/src/Bedrock.Framework/Server/ServerConnection.cs
+++ b/src/Bedrock.Framework/Server/ServerConnection.cs
@@ -13,12 +13,12 @@ namespace Bedrock.Framework
 {
     internal class ServerConnection : IConnectionHeartbeatFeature, IConnectionCompleteFeature, IConnectionLifetimeNotificationFeature, IConnectionEndPointFeature, IReadOnlyList<KeyValuePair<string, object>>
     {
-        private List<(Action<object> handler, object state)> _heartbeatHandlers;
+        private List<(Action<object> handler, object state)>? _heartbeatHandlers;
         private readonly object _heartbeatLock = new object();
 
-        private Stack<KeyValuePair<Func<object, Task>, object>> _onCompleted;
+        private Stack<KeyValuePair<Func<object, Task>, object>>? _onCompleted;
         private bool _completed;
-        private string _cachedToString;
+        private string? _cachedToString;
         private readonly CancellationTokenSource _connectionClosingCts = new CancellationTokenSource();
 
         public ServerConnection(long id, ConnectionContext connectionContext, ILogger logger)

--- a/src/Bedrock.Framework/Server/ServiceProviderExtensions.cs
+++ b/src/Bedrock.Framework/Server/ServiceProviderExtensions.cs
@@ -10,7 +10,7 @@ namespace Bedrock.Framework
     {
         internal static ILoggerFactory GetLoggerFactory(this IServiceProvider serviceProvider)
         {
-            return (ILoggerFactory)serviceProvider?.GetService(typeof(ILoggerFactory)) ?? NullLoggerFactory.Instance;
+            return (ILoggerFactory?)serviceProvider?.GetService(typeof(ILoggerFactory)) ?? NullLoggerFactory.Instance;
         }
     }
 }

--- a/src/Bedrock.Framework/Transports/Memory/MemoryTransport.cs
+++ b/src/Bedrock.Framework/Transports/Memory/MemoryTransport.cs
@@ -56,11 +56,11 @@ namespace Bedrock.Framework.Transports.Memory
 
         private class MemoryConnectionListener : IConnectionListener
         {
-            public EndPoint EndPoint { get; set; }
+            public EndPoint EndPoint { get; set; } = null!; // We should initialize this in the constructor
 
             internal Channel<ConnectionContext> AcceptQueue { get; } = Channel.CreateUnbounded<ConnectionContext>();
 
-            public async ValueTask<ConnectionContext> AcceptAsync(CancellationToken cancellationToken = default)
+            public async ValueTask<ConnectionContext?> AcceptAsync(CancellationToken cancellationToken = default)
             {
                 if (await AcceptQueue.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
                 {

--- a/src/Bedrock.Framework/Transports/Memory/MemoryTransport.cs
+++ b/src/Bedrock.Framework/Transports/Memory/MemoryTransport.cs
@@ -23,7 +23,7 @@ namespace Bedrock.Framework.Transports.Memory
             }
 
             MemoryConnectionListener listener;
-            _listeners[endpoint] = listener = new MemoryConnectionListener() { EndPoint = endpoint };
+            _listeners[endpoint] = listener = new MemoryConnectionListener(endpoint);
             return new ValueTask<IConnectionListener>(listener);
         }
 
@@ -56,7 +56,12 @@ namespace Bedrock.Framework.Transports.Memory
 
         private class MemoryConnectionListener : IConnectionListener
         {
-            public EndPoint EndPoint { get; set; } = null!; // We should initialize this in the constructor
+            public MemoryConnectionListener(EndPoint endPoint)
+            {
+                EndPoint = endPoint;
+            }
+
+            public EndPoint EndPoint { get; }
 
             internal Channel<ConnectionContext> AcceptQueue { get; } = Channel.CreateUnbounded<ConnectionContext>();
 

--- a/src/Bedrock.Framework/Transports/Sockets/SocketAwaitable.cs
+++ b/src/Bedrock.Framework/Transports/Sockets/SocketAwaitable.cs
@@ -16,7 +16,7 @@ namespace Bedrock.Framework
 
         private readonly PipeScheduler _ioScheduler;
 
-        private Action _callback;
+        private Action? _callback;
         private int _bytesTransferred;
         private SocketError _error;
 

--- a/src/Bedrock.Framework/Transports/Sockets/SocketConnection.cs
+++ b/src/Bedrock.Framework/Transports/Sockets/SocketConnection.cs
@@ -17,7 +17,7 @@ namespace Bedrock.Framework
         private readonly Socket _socket;
         private volatile bool _aborted;
         private readonly EndPoint _endPoint;
-        private IDuplexPipe _application;
+        private IDuplexPipe _application = null!;
         private readonly SocketSender _sender;
         private readonly SocketReceiver _receiver;
 
@@ -34,7 +34,7 @@ namespace Bedrock.Framework
             Features.Set<IConnectionInherentKeepAliveFeature>(this);
         }
 
-        public override IDuplexPipe Transport { get; set; }
+        public override IDuplexPipe? Transport { get; set; }
 
         public override IFeatureCollection Features { get; } = new FeatureCollection();
         public override string ConnectionId { get; set; } = Guid.NewGuid().ToString();
@@ -73,7 +73,7 @@ namespace Bedrock.Framework
 
         private async Task ExecuteAsync()
         {
-            Exception sendError = null;
+            Exception? sendError = null;
             try
             {
                 // Spawn send and receive logic
@@ -109,7 +109,7 @@ namespace Bedrock.Framework
 
         private async Task DoReceive()
         {
-            Exception error = null;
+            Exception? error = null;
 
             try
             {
@@ -189,9 +189,9 @@ namespace Bedrock.Framework
             }
         }
 
-        private async Task<Exception> DoSend()
+        private async Task<Exception?> DoSend()
         {
-            Exception error = null;
+            Exception? error = null;
 
             try
             {

--- a/src/Bedrock.Framework/Transports/Sockets/SocketSender.cs
+++ b/src/Bedrock.Framework/Transports/Sockets/SocketSender.cs
@@ -15,7 +15,7 @@ namespace Bedrock.Framework
         private readonly SocketAsyncEventArgs _eventArgs = new SocketAsyncEventArgs();
         private readonly SocketAwaitable _awaitable;
 
-        private List<ArraySegment<byte>> _bufferList;
+        private List<ArraySegment<byte>>? _bufferList;
 
         public SocketSender(Socket socket, PipeScheduler scheduler)
         {

--- a/src/Bedrock.Framework/Transports/Sockets/SocketsServerBuilder.cs
+++ b/src/Bedrock.Framework/Transports/Sockets/SocketsServerBuilder.cs
@@ -9,7 +9,7 @@ namespace Bedrock.Framework
 {
     public class SocketsServerBuilder
     {
-        private List<(EndPoint EndPoint, int Port, Action<IConnectionBuilder> Application)> _bindings = new List<(EndPoint, int, Action<IConnectionBuilder>)>();
+        private List<(EndPoint? EndPoint, int Port, Action<IConnectionBuilder> Application)> _bindings = new List<(EndPoint?, int, Action<IConnectionBuilder>)>();
 
         public SocketTransportOptions Options { get; } = new SocketTransportOptions();
 


### PR DESCRIPTION
The first commit enable NRTs and adds annotations to suppress/fix all errors.

Later commits do minor refactorings in some places to remove null suppression operators.

There are other places where refactoring could also fix things potentially, but they are more complex - anywhere I added a `!` is a potential candidate. There are 8 remaining usages of the null suppression operator.