### PR TITLE
Pass CancellationTokens  to methods in HttpProtocols

### DIFF
--- a/src/Bedrock.Framework.Experimental/Protocols/HttpClientProtocol.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/HttpClientProtocol.cs
@@ -26,7 +26,7 @@ namespace Bedrock.Framework.Protocols
             _messageWriter = new Http1RequestMessageWriter(host, port);
         }
 
-        public async ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage requestMessage, HttpCompletionOption completionOption = HttpCompletionOption.ResponseHeadersRead)
+        public async ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage requestMessage, HttpCompletionOption completionOption = HttpCompletionOption.ResponseHeadersRead, System.Threading.CancellationToken cancellationToken = default)
         {
             // Write request message headers
             _messageWriter.WriteMessage(requestMessage, _connection.Transport.Output);
@@ -37,12 +37,12 @@ namespace Bedrock.Framework.Protocols
                 await requestMessage.Content.CopyToAsync(_connection.Transport.Output.AsStream()).ConfigureAwait(false);
             }
 
-            await _connection.Transport.Output.FlushAsync().ConfigureAwait(false);
+            await _connection.Transport.Output.FlushAsync(cancellationToken).ConfigureAwait(false);
 
             var content = new HttpBodyContent();
             var headerReader = new Http1ResponseMessageReader(content);
 
-            var result = await _reader.ReadAsync(headerReader).ConfigureAwait(false);
+            var result = await _reader.ReadAsync(headerReader, cancellationToken).ConfigureAwait(false);
 
             if (result.IsCompleted)
             {

--- a/src/Bedrock.Framework.Experimental/Protocols/HttpServerProtocol.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/HttpServerProtocol.cs
@@ -17,12 +17,12 @@ namespace Bedrock.Framework.Protocols
             _reader = connection.CreateReader();
         }
 
-        public async ValueTask<HttpRequestMessage> ReadRequestAsync()
+        public async ValueTask<HttpRequestMessage> ReadRequestAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             var content = new HttpBodyContent();
             var headerReader = new Http1RequestMessageReader(content);
 
-            var result = await _reader.ReadAsync(headerReader).ConfigureAwait(false);
+            var result = await _reader.ReadAsync(headerReader, cancellationToken).ConfigureAwait(false);
 
             if (result.IsCompleted)
             {
@@ -50,7 +50,7 @@ namespace Bedrock.Framework.Protocols
             return request;
         }
 
-        public async ValueTask WriteResponseAsync(HttpResponseMessage responseMessage)
+        public async ValueTask WriteResponseAsync(HttpResponseMessage responseMessage, System.Threading.CancellationToken cancellationToken = default)
         {
             _writer.WriteMessage(responseMessage, _connection.Transport.Output);
 


### PR DESCRIPTION
Pass in CancellationTokens to HttpClientProtocol.SendAsync, HttpServerProtocol.ReadRequestAsync & HttpServerProtocol.WriteResponseAsync

The token in HttpServerProtocol.WriteResponseAsync seems to be a bit redundant. But it may later be be integrated usefully