### PR TITLE
wireshark style logging

### DIFF
--- a/samples/ClientApplication/Program.cs
+++ b/samples/ClientApplication/Program.cs
@@ -267,7 +267,7 @@ namespace ClientApplication
         {
             var client = new ClientBuilder(serviceProvider)
                         .UseConnectionFactory(new NamedPipeConnectionFactory())
-                        .UseConnectionLogging()
+                        .UseConnectionLogging(loggingFormatter: LoggingFormatting.Wireshark)
                         .Build();
 
             await using var connection = await client.ConnectAsync(new NamedPipeEndPoint("docker_engine"));

--- a/src/Bedrock.Framework/Middleware/ConnectionBuilderExtensions.cs
+++ b/src/Bedrock.Framework/Middleware/ConnectionBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Bedrock.Framework.Infrastructure;
 using Bedrock.Framework.Middleware.Tls;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,6 +10,64 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Bedrock.Framework
 {
+    public delegate void LoggingFormatter(ILogger logger, string method, ReadOnlySpan<byte> buffer);
+
+    public class LoggingFormatting
+    {
+        public static void Wireshark(ILogger logger, string method, ReadOnlySpan<byte> buffer)
+        {
+            if (!logger.IsEnabled(LogLevel.Debug))
+            {
+                return;
+            }
+
+            var builder = new StringBuilder();
+            builder.AppendLine($"{method}[{buffer.Length}]");
+            var charBuilder = new StringBuilder();
+
+            // Write the hex
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                builder.Append(buffer[i].ToString("X2"));
+                builder.Append(" ");
+
+                var bufferChar = (char)buffer[i];
+                if (Char.IsControl(bufferChar))
+                {
+                    charBuilder.Append(".");
+                }
+                else
+                {
+                    charBuilder.Append(bufferChar);
+                }
+
+                if ((i + 1) % 16 == 0)
+                {
+                    builder.Append("  ");
+                    builder.Append(charBuilder.ToString());
+                    builder.AppendLine();
+                    charBuilder.Clear();
+                }
+                else if ((i + 1) % 8 == 0)
+                {
+                    builder.Append(" ");
+                    charBuilder.Append(" ");
+                }
+            }
+            if (charBuilder.Length > 0)
+            {
+                // 2 (between hex and char blocks) + num bytes left (3 per byte)
+                builder.Append(string.Empty.PadRight(2+(3 * (16 - charBuilder.Length))));
+                // extra for space after 8th byte
+                if (charBuilder.Length < 8)
+                    builder.Append(" ");
+                builder.Append(charBuilder.ToString());
+            }
+
+            logger.LogDebug(builder.ToString());
+        }
+    }
+
     public static class ConnectionBuilderExtensions
     {
         /// <summary>
@@ -17,22 +76,11 @@ namespace Bedrock.Framework
         /// <returns>
         /// The <see cref="ListenOptions"/>.
         /// </returns>
-        public static TBuilder UseConnectionLogging<TBuilder>(this TBuilder builder) where TBuilder : IConnectionBuilder
-        {
-            return builder.UseConnectionLogging(loggerName: null);
-        }
-
-        /// <summary>
-        /// Emits verbose logs for bytes read from and written to the connection.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="ListenOptions"/>.
-        /// </returns>
-        public static TBuilder UseConnectionLogging<TBuilder>(this TBuilder builder, string loggerName) where TBuilder : IConnectionBuilder
+        public static TBuilder UseConnectionLogging<TBuilder>(this TBuilder builder, string loggerName = null, LoggingFormatter loggingFormatter = null) where TBuilder : IConnectionBuilder
         {
             var loggerFactory = builder.ApplicationServices.GetRequiredService<ILoggerFactory>();
             var logger = loggerName == null ? loggerFactory.CreateLogger<LoggingConnectionMiddleware>() : loggerFactory.CreateLogger(loggerName);
-            builder.Use(next => new LoggingConnectionMiddleware(next, logger).OnConnectionAsync);
+            builder.Use(next => new LoggingConnectionMiddleware(next, logger, loggingFormatter).OnConnectionAsync);
             return builder;
         }
 

--- a/src/Bedrock.Framework/Middleware/Internal/LoggingStream.cs
+++ b/src/Bedrock.Framework/Middleware/Internal/LoggingStream.cs
@@ -14,11 +14,13 @@ namespace Bedrock.Framework.Infrastructure
     {
         private readonly Stream _inner;
         private readonly ILogger _logger;
+        private readonly LoggingFormatter _logFormatter;
 
-        public LoggingStream(Stream inner, ILogger logger)
+        public LoggingStream(Stream inner, ILogger logger, LoggingFormatter logFormatter = null)
         {
             _inner = inner;
             _logger = logger;
+            _logFormatter = logFormatter;
         }
 
         public override bool CanRead
@@ -140,6 +142,12 @@ namespace Bedrock.Framework.Infrastructure
 
         private void Log(string method, ReadOnlySpan<byte> buffer)
         {
+            if (_logFormatter != null)
+            {
+                _logFormatter(_logger, method, buffer);
+                return;
+            }
+
             if (!_logger.IsEnabled(LogLevel.Debug))
             {
                 return;

--- a/src/Bedrock.Framework/Middleware/LoggingConnectionMiddleware.cs
+++ b/src/Bedrock.Framework/Middleware/LoggingConnectionMiddleware.cs
@@ -14,11 +14,13 @@ namespace Bedrock.Framework
     {
         private readonly ConnectionDelegate _next;
         private readonly ILogger _logger;
+        private readonly LoggingFormatter _loggingFormatter;
 
-        public LoggingConnectionMiddleware(ConnectionDelegate next, ILogger logger)
+        public LoggingConnectionMiddleware(ConnectionDelegate next, ILogger logger, LoggingFormatter loggingFormatter = null)
         {
             _next = next ?? throw new ArgumentNullException(nameof(next));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _loggingFormatter = loggingFormatter;
         }
 
         public async Task OnConnectionAsync(ConnectionContext context)
@@ -27,7 +29,7 @@ namespace Bedrock.Framework
 
             try
             {
-                await using (var loggingDuplexPipe = new LoggingDuplexPipe(context.Transport, _logger))
+                await using (var loggingDuplexPipe = new LoggingDuplexPipe(context.Transport, _logger, _loggingFormatter))
                 {
                     context.Transport = loggingDuplexPipe;
 
@@ -42,8 +44,8 @@ namespace Bedrock.Framework
 
         private class LoggingDuplexPipe : DuplexPipeStreamAdapter<LoggingStream>
         {
-            public LoggingDuplexPipe(IDuplexPipe transport, ILogger logger) :
-                base(transport, stream => new LoggingStream(stream, logger))
+            public LoggingDuplexPipe(IDuplexPipe transport, ILogger logger, LoggingFormatter loggingFormatter) :
+                base(transport, stream => new LoggingStream(stream, logger, loggingFormatter))
             {
             }
         }


### PR DESCRIPTION
allows different formatting of Logging middleware.
Provider formatter for WireShark style.

Have made the formattter configurable. But could just replace the existing `Log` method is you want to keep this simple