### PR TITLE
http over NamedPipe

### DIFF
--- a/src/Bedrock.Framework.Experimental/Protocols/HttpClientProtocol.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/HttpClientProtocol.cs
@@ -21,6 +21,7 @@ namespace Bedrock.Framework.Protocols
             {
                 UriEndPoint uriEndPoint => (uriEndPoint.Uri.Host, uriEndPoint.Uri.Port),
                 IPEndPoint ip => (ip.Address.ToString(), ip.Port),
+                NamedPipeEndPoint np => (np.PipeName, 80),
                 _ => throw new NotSupportedException($"{connection.RemoteEndPoint} not supported")
             };
             _messageWriter = new Http1RequestMessageWriter(host, port);

--- a/src/Bedrock.Framework.Experimental/Transports/Pipes/NamedPipeConnectionContext.cs
+++ b/src/Bedrock.Framework.Experimental/Transports/Pipes/NamedPipeConnectionContext.cs
@@ -13,11 +13,12 @@ namespace Bedrock.Framework
     {
         private readonly PipeStream _stream;
 
-        public NamedPipeConnectionContext(PipeStream stream)
+        public NamedPipeConnectionContext(PipeStream stream, NamedPipeEndPoint endPoint)
         {
             _stream = stream;
             Transport = this;
             ConnectionId = Guid.NewGuid().ToString();
+            RemoteEndPoint = endPoint;
 
             Input = PipeReader.Create(stream);
             Output = PipeWriter.Create(stream);

--- a/src/Bedrock.Framework.Experimental/Transports/Pipes/NamedPipeConnectionFactory.cs
+++ b/src/Bedrock.Framework.Experimental/Transports/Pipes/NamedPipeConnectionFactory.cs
@@ -19,7 +19,7 @@ namespace Bedrock.Framework
             var pipeStream = new NamedPipeClientStream(np.ServerName, np.PipeName, PipeDirection.InOut, np.PipeOptions);
             await pipeStream.ConnectAsync(cancellationToken).ConfigureAwait(false);
 
-            return new NamedPipeConnectionContext(pipeStream);
+            return new NamedPipeConnectionContext(pipeStream, np);
         }
     }
 }

--- a/src/Bedrock.Framework.Experimental/Transports/Pipes/NamedPipeConnectionListener.cs
+++ b/src/Bedrock.Framework.Experimental/Transports/Pipes/NamedPipeConnectionListener.cs
@@ -54,7 +54,7 @@ namespace Bedrock.Framework
                     break;
                 }
 
-                _acceptedQueue.Writer.TryWrite(new NamedPipeConnectionContext(stream));
+                _acceptedQueue.Writer.TryWrite(new NamedPipeConnectionContext(stream, _endpoint));
             }
 
             _acceptedQueue.Writer.TryComplete();


### PR DESCRIPTION
flow endpoint through NamedPipe bits such that `HttpClientProtocol` and `Http1RequestMessageWriter` are "happy"