### PR TITLE
Naive update tf to net5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,9 @@ jobs:
     - uses: actions/checkout@v1
       
     - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v1.4.0
+      uses: actions/setup-dotnet@v1
       with:
-        version: 5.0.100
+        dotnet-version: '5.0.x'
      
     - name: dotnet build
       run: dotnet build BedrockFramework.sln -c Release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1.4.0
       with:
-        version: 3.1.100
+        version: 5.0.100
      
     - name: dotnet build
       run: dotnet build BedrockFramework.sln -c Release

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup Condition="$(IsPackable) == 'true'">
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.0.28</Version>
+      <Version>3.3.37</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>

--- a/samples/ClientApplication/ClientApplication.csproj
+++ b/samples/ClientApplication/ClientApplication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,8 +14,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.0.0" />
-    <PackageReference Include="MQTTnet.AspNetCore" Version="3.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.0" />
+    <PackageReference Include="MQTTnet.AspNetCore" Version="3.0.13" />
   </ItemGroup>
   
   <ItemGroup>

--- a/samples/ServerApplication/ServerApplication.csproj
+++ b/samples/ServerApplication/ServerApplication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MQTTnet.AspNetCore" Version="3.0.8" />
+    <PackageReference Include="MQTTnet.AspNetCore" Version="3.0.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bedrock.Framework.Experimental/Bedrock.Framework.Experimental.csproj
+++ b/src/Bedrock.Framework.Experimental/Bedrock.Framework.Experimental.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageDescription>Experimental protocols and transports for Bedrock.Framework.</PackageDescription>
     <Authors>David Fowler</Authors>
@@ -17,7 +17,7 @@
     <ProjectReference Include="..\Bedrock.Framework\Bedrock.Framework.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="3.1.0" />
+  <ItemGroup> 
+    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Bedrock.Framework.Experimental/Protocols/Http1RequestMessageReader.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Http1RequestMessageReader.cs
@@ -54,7 +54,7 @@ namespace Bedrock.Framework.Protocols
                     goto case State.Headers;
 
                 case State.Headers:
-                    while (sequenceReader.TryReadTo(out var headerLine, NewLine))
+                    while (sequenceReader.TryReadTo(out ReadOnlySequence<byte> headerLine, NewLine))
                     {
                         if (headerLine.Length == 0)
                         {

--- a/src/Bedrock.Framework.Experimental/Protocols/Http1ResponseMessageReader.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Http1ResponseMessageReader.cs
@@ -59,7 +59,7 @@ namespace Bedrock.Framework.Protocols
                     goto case State.Headers;
 
                 case State.Headers:
-                    while (sequenceReader.TryReadTo(out var headerLine, NewLine))
+                    while (sequenceReader.TryReadTo(out ReadOnlySequence<byte> headerLine, NewLine))
                     {
                         if (headerLine.Length == 0)
                         {

--- a/src/Bedrock.Framework/Bedrock.Framework.csproj
+++ b/src/Bedrock.Framework/Bedrock.Framework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <PackageDescription>High performance, low level networking APIs for building custom severs and clients.</PackageDescription>
     <Authors>David Fowler</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -12,6 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipelines" Version="4.7.2" />
+    <PackageReference Include="System.IO.Pipelines" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/Bedrock.Framework.Benchmarks/Bedrock.Framework.Benchmarks.csproj
+++ b/tests/Bedrock.Framework.Benchmarks/Bedrock.Framework.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Bedrock.Framework.Tests/Bedrock.Framework.Tests.csproj
+++ b/tests/Bedrock.Framework.Tests/Bedrock.Framework.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />


### PR DESCRIPTION
As said, this is a very super naive update to `net5.0`
Especially in the very short term to have transitive resolving `Msft.Anc.xxxx` in 5.0.x rather than 3.1.x

I see you also have a branch ongoing during `5.0-preview`, but not sure if I should attempt to rebase that other branch, or anything else already on the way
