### PR TITLE
Clear the buffer and cursors if we don't have a full message

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
 
     - name: setup nuget
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      uses: NuGet/setup-nuget@v1.0.2
+      uses: NuGet/setup-nuget@v1.0.5
       with:
         nuget-version: latest
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-      
+
+    - uses: aarnott/nbgv@v0.4.0
+      with:
+        setAllVars: true
+
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1.7.2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
       
     - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v1.4.0
+      uses: actions/setup-dotnet@v1.7.2
       with:
         version: 3.1.100
      

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup Condition="$(IsPackable) == 'true'">
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.0.28</Version>
+      <Version>3.3.37</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>

--- a/src/Bedrock.Framework/Protocols/ProtocolReader.cs
+++ b/src/Bedrock.Framework/Protocols/ProtocolReader.cs
@@ -18,7 +18,7 @@ namespace Bedrock.Framework.Protocols
         private bool _hasMessage;
         private bool _disposed;
 
-        public ProtocolReader(Stream stream) : 
+        public ProtocolReader(Stream stream) :
             this(PipeReader.Create(stream))
         {
 
@@ -67,6 +67,11 @@ namespace Bedrock.Framework.Protocols
             {
                 // We couldn't parse the message so advance the input so we can read
                 _reader.AdvanceTo(_consumed, _examined);
+
+                // Reset the state since we're done consuming this buffer
+                _buffer = default;
+                _consumed = default;
+                _examined = default;
             }
 
             if (_isCompleted)
@@ -160,6 +165,11 @@ namespace Bedrock.Framework.Protocols
             else
             {
                 _reader.AdvanceTo(_consumed, _examined);
+
+                // Reset the state since we're done consuming this buffer
+                _buffer = default;
+                _consumed = default;
+                _examined = default;
             }
 
             if (_isCompleted)


### PR DESCRIPTION
- This makes sure we aren't left in a corrupted state

Fixes #115