### PR TITLE
LengthPrefixedProtocol: Exclude prefix bytes in check for enough remaining data

### DIFF
--- a/samples/ServerApplication/LengthPrefixedProtocol.cs
+++ b/samples/ServerApplication/LengthPrefixedProtocol.cs
@@ -10,7 +10,7 @@ namespace Protocols
         public bool TryParseMessage(in ReadOnlySequence<byte> input, ref SequencePosition consumed, ref SequencePosition examined, out Message message)
         {
             var reader = new SequenceReader<byte>(input);
-            if (!reader.TryReadBigEndian(out int length) || input.Length < length)
+            if (!reader.TryReadBigEndian(out int length) || reader.Remaining < length)
             {
                 message = default;
                 return false;


### PR DESCRIPTION
Fixes https://github.com/davidfowl/BedrockFramework/issues/116
