### PR TITLE
Framing - Variable size length fielded protocol

### DIFF
--- a/samples/ClientApplication/ClientApplication.csproj
+++ b/samples/ClientApplication/ClientApplication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +18,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.0" />
-    <PackageReference Include="MQTTnet.AspNetCore" Version="3.1.0" />
+    <PackageReference Include="MQTTnet.AspNetCore" Version="3.1.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/samples/ClientApplication/ClientApplication.csproj
+++ b/samples/ClientApplication/ClientApplication.csproj
@@ -6,6 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\ServerApplication\Framing\VariableSizeLengthFielded\Header.cs" Link="Framing\VariableSizeLengthFielded\Header.cs" />
+    <Compile Include="..\ServerApplication\Framing\VariableSizeLengthFielded\HeaderFactory.cs" Link="Framing\VariableSizeLengthFielded\HeaderFactory.cs" />
+    <Compile Include="..\ServerApplication\Framing\VariableSizeLengthFielded\Helper.cs" Link="Framing\VariableSizeLengthFielded\Helper.cs" />
     <Compile Include="..\ServerApplication\LengthPrefixedProtocol.cs" Link="LengthPrefixedProtocol.cs" />
   </ItemGroup>
 
@@ -20,6 +23,10 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\src\Bedrock.Framework.Experimental\Bedrock.Framework.Experimental.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Folder Include="Framing\VariableSizeLengthFielded\" />
   </ItemGroup>
 
 </Project>

--- a/samples/ClientApplication/ClientApplication.csproj
+++ b/samples/ClientApplication/ClientApplication.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.0-rc.2.21480.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.0" />
     <PackageReference Include="MQTTnet.AspNetCore" Version="3.1.0" />
   </ItemGroup>
   

--- a/samples/ClientApplication/ClientApplication.csproj
+++ b/samples/ClientApplication/ClientApplication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,8 +14,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.0.0" />
-    <PackageReference Include="MQTTnet.AspNetCore" Version="3.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.0-rc.2.21480.10" />
+    <PackageReference Include="MQTTnet.AspNetCore" Version="3.1.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/samples/ServerApplication/Framing/VariableSizeLengthFielded/Header.cs
+++ b/samples/ServerApplication/Framing/VariableSizeLengthFielded/Header.cs
@@ -1,0 +1,45 @@
+﻿using Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFielded;
+using System;
+
+namespace ServerApplication.Framing.VariableSizeLengthFielded
+{
+    internal class Header : IHeader
+    {
+        public int PayloadLength { get; }
+        public int SomeCustomData { get; }
+        
+        public Header(int payloadLength, int someCustomData)
+        {
+            PayloadLength = payloadLength;
+            SomeCustomData = someCustomData;
+        }
+
+        public Header(ReadOnlySpan<byte> headerAsSpan)
+        {
+            PayloadLength = BitConverter.ToInt32(headerAsSpan.Slice(0, 4));
+            SomeCustomData = BitConverter.ToInt32(headerAsSpan.Slice(4));
+        }
+
+        public ReadOnlySpan<byte> AsSpan()
+        {
+            var payloadLengthAsArray = BitConverter.GetBytes(PayloadLength);
+            var someCustomDataAsArray = BitConverter.GetBytes(SomeCustomData);
+
+            byte[] header = new byte[Helper.HeaderLength];
+            header[0] = payloadLengthAsArray[0];
+            header[1] = payloadLengthAsArray[1];
+            header[2] = payloadLengthAsArray[2];
+            header[3] = payloadLengthAsArray[3];
+            header[4] = someCustomDataAsArray[0];
+            header[5] = someCustomDataAsArray[1];
+            header[6] = someCustomDataAsArray[2];
+            header[7] = someCustomDataAsArray[3];
+            return header.AsSpan();
+        }
+
+        public override string ToString()
+        {
+            return $"Payload length: {PayloadLength} - Some custom data: {SomeCustomData}";
+        }
+    }
+}

--- a/samples/ServerApplication/Framing/VariableSizeLengthFielded/HeaderFactory.cs
+++ b/samples/ServerApplication/Framing/VariableSizeLengthFielded/HeaderFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers;
 
 namespace ServerApplication.Framing.VariableSizeLengthFielded
@@ -21,6 +21,6 @@ namespace ServerApplication.Framing.VariableSizeLengthFielded
             }
         }
 
-        public Header CreateHeader(in ReadOnlySpan<byte> headerData) => new(headerData);
+        public Header CreateHeader(in ReadOnlySpan<byte> headerData) => new Header(headerData);
     }
 }

--- a/samples/ServerApplication/Framing/VariableSizeLengthFielded/HeaderFactory.cs
+++ b/samples/ServerApplication/Framing/VariableSizeLengthFielded/HeaderFactory.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Buffers;
+
+namespace ServerApplication.Framing.VariableSizeLengthFielded
+{
+    internal class HeaderFactory
+    {
+        public Header CreateHeader(int payloadLength, int someCustomData) => new Header(payloadLength, someCustomData);
+
+        public Header CreateHeader(in ReadOnlySequence<byte> headerSequence)
+        {
+            if (headerSequence.IsSingleSegment)
+            {
+                return CreateHeader(headerSequence.FirstSpan);
+            }
+            else
+            {
+                Span<byte> headerData = stackalloc byte[Helper.HeaderLength];
+                headerSequence.CopyTo(headerData);
+                return CreateHeader(headerData);
+            }
+        }
+
+        public Header CreateHeader(in ReadOnlySpan<byte> headerData) => new(headerData);
+    }
+}

--- a/samples/ServerApplication/Framing/VariableSizeLengthFielded/HeaderPrefixedApplication.cs
+++ b/samples/ServerApplication/Framing/VariableSizeLengthFielded/HeaderPrefixedApplication.cs
@@ -1,0 +1,53 @@
+﻿using Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFielded;
+using Bedrock.Framework.Protocols;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Logging;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ServerApplication.Framing.VariableSizeLengthFielded
+{
+    internal class HeaderPrefixedApplication : ConnectionHandler
+    {
+        private readonly ILogger _logger;
+        private readonly HeaderFactory _headerFactory;
+
+        public HeaderPrefixedApplication(ILogger<MyCustomProtocol> logger, HeaderFactory headerFactory)
+        {
+            _logger = logger ?? throw new System.ArgumentNullException(nameof(logger));
+            _headerFactory = headerFactory ?? throw new System.ArgumentNullException(nameof(headerFactory));
+        }
+
+        public override async Task OnConnectedAsync(ConnectionContext connection)
+        {
+            _logger.LogInformation("{ConnectionId} connected.", connection.ConnectionId);
+
+            // Use a header prefixed protocol
+            var protocol = new VariableSizeLengthFieldedProtocol(Helper.HeaderLength, (headerSequence) => _headerFactory.CreateHeader(headerSequence));
+            var reader = connection.CreateReader();
+            var writer = connection.CreateWriter();
+
+            while (true)
+            {
+                try
+                {
+                    var result = await reader.ReadAsync(protocol);
+                    var message = result.Message;
+
+                    _logger.LogInformation("Message received - Header: ({Header}) -  Payload: ({Payload})", message.Header, Encoding.UTF8.GetString(message.Payload));
+
+                    if (result.IsCompleted)
+                    {
+                        break;
+                    }
+                }
+                finally
+                {
+                    reader.Advance();
+                }
+            }
+
+            _logger.LogInformation("{ConnectionId} disconnected.", connection.ConnectionId);
+        }
+    }
+}

--- a/samples/ServerApplication/Framing/VariableSizeLengthFielded/HeaderPrefixedApplication.cs
+++ b/samples/ServerApplication/Framing/VariableSizeLengthFielded/HeaderPrefixedApplication.cs
@@ -1,7 +1,8 @@
-﻿using Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFielded;
+using Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFielded;
 using Bedrock.Framework.Protocols;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
+using System.Buffers;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -34,7 +35,7 @@ namespace ServerApplication.Framing.VariableSizeLengthFielded
                     var result = await reader.ReadAsync(protocol);
                     var message = result.Message;
 
-                    _logger.LogInformation("Message received - Header: ({Header}) -  Payload: ({Payload})", message.Header, Encoding.UTF8.GetString(message.Payload));
+                    _logger.LogInformation("Message received - Header: ({Header}) -  Payload: ({Payload})", message.Header, Encoding.UTF8.GetString(message.Payload.ToArray()));
 
                     if (result.IsCompleted)
                     {

--- a/samples/ServerApplication/Framing/VariableSizeLengthFielded/HeaderPrefixedApplication.cs
+++ b/samples/ServerApplication/Framing/VariableSizeLengthFielded/HeaderPrefixedApplication.cs
@@ -10,10 +10,10 @@ namespace ServerApplication.Framing.VariableSizeLengthFielded
 {
     internal class HeaderPrefixedApplication : ConnectionHandler
     {
-        private readonly ILogger _logger;
+        private readonly ILogger<HeaderPrefixedApplication> _logger;
         private readonly HeaderFactory _headerFactory;
 
-        public HeaderPrefixedApplication(ILogger<MyCustomProtocol> logger, HeaderFactory headerFactory)
+        public HeaderPrefixedApplication(ILogger<HeaderPrefixedApplication> logger, HeaderFactory headerFactory)
         {
             _logger = logger ?? throw new System.ArgumentNullException(nameof(logger));
             _headerFactory = headerFactory ?? throw new System.ArgumentNullException(nameof(headerFactory));

--- a/samples/ServerApplication/Framing/VariableSizeLengthFielded/Helper.cs
+++ b/samples/ServerApplication/Framing/VariableSizeLengthFielded/Helper.cs
@@ -1,0 +1,7 @@
+﻿namespace ServerApplication.Framing.VariableSizeLengthFielded
+{
+    internal static class Helper
+    {
+        public static int HeaderLength => 8;
+    }
+}

--- a/samples/ServerApplication/MqttApplication.cs
+++ b/samples/ServerApplication/MqttApplication.cs
@@ -19,7 +19,7 @@ namespace ServerApplication
         {
             while (true)
             {
-                var packet = await adapter.ReceivePacketAsync(Timeout.InfiniteTimeSpan, default);
+                var packet = await adapter.ReceivePacketAsync(default);
 
                 switch (packet)
                 {
@@ -29,8 +29,7 @@ namespace ServerApplication
                             ReturnCode = MqttConnectReturnCode.ConnectionAccepted,
                             ReasonCode = MqttConnectReasonCode.Success,
                             IsSessionPresent = false
-                        }, Timeout.InfiniteTimeSpan,
-                        default);
+                        }, default);
                         break;
                     case MqttDisconnectPacket disconnectPacket:
                         break;
@@ -48,7 +47,7 @@ namespace ServerApplication
                         };
                         ack.ReasonCodes.Add(MqttSubscribeReasonCode.GrantedQoS0);
 
-                        await adapter.SendPacketAsync(ack, Timeout.InfiniteTimeSpan, default);
+                        await adapter.SendPacketAsync(ack, default);
                         break;
                     default:
                         break;

--- a/samples/ServerApplication/MyCustomProtocol.cs
+++ b/samples/ServerApplication/MyCustomProtocol.cs
@@ -17,6 +17,8 @@ namespace ServerApplication
 
         public override async Task OnConnectedAsync(ConnectionContext connection)
         {
+            _logger.LogInformation("{ConnectionId} connected.", connection.ConnectionId);
+
             // Use a length prefixed protocol
             var protocol = new LengthPrefixedProtocol();
             var reader = connection.CreateReader();
@@ -43,6 +45,8 @@ namespace ServerApplication
                     reader.Advance();
                 }
             }
+
+            _logger.LogInformation("{ConnectionId} disconnected.", connection.ConnectionId);
         }
     }
 }

--- a/samples/ServerApplication/Program.cs
+++ b/samples/ServerApplication/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using ServerApplication.Framing.VariableSizeLengthFielded;
 
 namespace ServerApplication
 {
@@ -21,8 +22,9 @@ namespace ServerApplication
                 builder.SetMinimumLevel(LogLevel.Debug);
                 builder.AddConsole();
             });
-
+            
             services.AddSignalR();
+            services.AddSingleton<HeaderFactory>();
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -46,18 +48,23 @@ namespace ServerApplication
                                 builder => builder.UseConnectionLogging().UseConnectionHandler<MqttApplication>());
 
                             // Echo Server with TLS
-                            sockets.Listen(IPAddress.Loopback, 5004,
-                                builder => builder.UseServerTls(options =>
-                                {
-                                    options.LocalCertificate = new X509Certificate2("testcert.pfx", "testcert");
+                            //sockets.Listen(IPAddress.Loopback, 5004,
+                            //    builder => builder.UseServerTls(options =>
+                            //    {
+                            //        options.LocalCertificate = new X509Certificate2("testcert.pfx", "testcert");
 
-                                    // NOTE: Do not do this in a production environment
-                                    options.AllowAnyRemoteCertificate();
-                                })
-                                .UseConnectionLogging().UseConnectionHandler<EchoServerApplication>());
+                            //        // NOTE: Do not do this in a production environment
+                            //        options.AllowAnyRemoteCertificate();
+                            //    })
+                            //    .UseConnectionLogging().UseConnectionHandler<EchoServerApplication>());
 
+                            // Lenght prefixed server
                             sockets.Listen(IPAddress.Loopback, 5005,
                                 builder => builder.UseConnectionLogging().UseConnectionHandler<MyCustomProtocol>());
+
+                            // Header prefixed server
+                            sockets.Listen(IPAddress.Loopback, 5006,
+                                builder => builder.UseConnectionLogging().UseConnectionHandler<HeaderPrefixedApplication>());
                         })
                         .Build();
 

--- a/samples/ServerApplication/ServerApplication.csproj
+++ b/samples/ServerApplication/ServerApplication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MQTTnet.AspNetCore" Version="3.1.0" />
+    <PackageReference Include="MQTTnet.AspNetCore" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ServerApplication/ServerApplication.csproj
+++ b/samples/ServerApplication/ServerApplication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MQTTnet.AspNetCore" Version="3.0.8" />
+    <PackageReference Include="MQTTnet.AspNetCore" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bedrock.Framework.Experimental/Bedrock.Framework.Experimental.csproj
+++ b/src/Bedrock.Framework.Experimental/Bedrock.Framework.Experimental.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageDescription>Experimental protocols and transports for Bedrock.Framework.</PackageDescription>
     <Authors>David Fowler</Authors>
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="6.0.0-rc.2.21480.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
   </ItemGroup>
 </Project>

--- a/src/Bedrock.Framework.Experimental/Bedrock.Framework.Experimental.csproj
+++ b/src/Bedrock.Framework.Experimental/Bedrock.Framework.Experimental.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageDescription>Experimental protocols and transports for Bedrock.Framework.</PackageDescription>
     <Authors>David Fowler</Authors>
@@ -18,10 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="5.0.12" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
   </ItemGroup>
 </Project>

--- a/src/Bedrock.Framework.Experimental/Bedrock.Framework.Experimental.csproj
+++ b/src/Bedrock.Framework.Experimental/Bedrock.Framework.Experimental.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="6.0.0-rc.2.21480.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/Frame.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/Frame.cs
@@ -10,6 +10,10 @@ namespace Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFie
         public Frame(IHeader header, byte[] payload) : this(header, new ReadOnlySequence<byte>(payload))
         {
         }
+        
+        public Frame(IHeader header, ReadOnlyMemory<byte> payload) : this(header, new ReadOnlySequence<byte>(payload))
+        {
+        }
 
         public Frame(IHeader header, ReadOnlySequence<byte> payload)
         {

--- a/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/Frame.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/Frame.cs
@@ -1,0 +1,20 @@
+﻿using System.Buffers;
+
+namespace Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFielded
+{
+    public readonly struct Frame
+    {
+        public readonly IHeader Header { get; }
+        public readonly ReadOnlySequence<byte> Payload { get; }
+
+        public Frame(IHeader header, byte[] payload) : this(header, new ReadOnlySequence<byte>(payload))
+        {
+        }
+
+        public Frame(IHeader header, ReadOnlySequence<byte> payload)
+        {
+            Header = header;
+            Payload = payload;
+        }
+    }
+}

--- a/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/IHeader.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/IHeader.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFielded
+{
+    public interface IHeader
+    {
+        public int PayloadLength { get; }
+
+        public ReadOnlySpan<byte> AsSpan();
+    }
+}

--- a/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/VariableSizeLengthFieldedProtocol.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/VariableSizeLengthFieldedProtocol.cs
@@ -64,8 +64,8 @@ namespace Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFie
 
         private bool TryParsePayload(in ReadOnlySequence<byte> input, out ReadOnlySequence<byte> payloadSequence)
         {
-            int messageLength = _headerLength + _header.PayloadLength;
-            if (input.Length < messageLength)
+            int frameLength = _headerLength + _header.PayloadLength;
+            if (input.Length < frameLength)
             {
                 payloadSequence = default;
                 return false;
@@ -77,13 +77,13 @@ namespace Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFie
         #endregion
 
         #region IMessageWriter
-        public void WriteMessage(Frame message, IBufferWriter<byte> output)
+        public void WriteMessage(Frame frame, IBufferWriter<byte> output)
         {
             // Header
-            output.Write(message.Header.AsSpan());
+            output.Write(frame.Header.AsSpan());
 
             // Payload
-            foreach (var payloadSegment in message.Payload)
+            foreach (var payloadSegment in frame.Payload)
             {
                 output.Write(payloadSegment.Span);
             }

--- a/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/VariableSizeLengthFieldedProtocol.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/VariableSizeLengthFieldedProtocol.cs
@@ -1,0 +1,93 @@
+﻿using Bedrock.Framework.Protocols;
+using System;
+using System.Buffers;
+
+namespace Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFielded
+{
+    public class VariableSizeLengthFieldedProtocol : IMessageReader<Frame>, IMessageWriter<Frame>
+    {
+        private readonly int _headerLength;
+        private readonly Func<ReadOnlySequence<byte>, IHeader> _createHeader;
+
+        private IHeader? _header;
+
+        public VariableSizeLengthFieldedProtocol(int headerLength, Func<ReadOnlySequence<byte>, IHeader> createHeader)
+        {
+            if (headerLength <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(headerLength), "Header length must be greater than 0.");
+            }
+
+            _headerLength = headerLength;
+            _createHeader = createHeader ?? throw new ArgumentNullException(nameof(createHeader));
+        }
+
+        #region IMessageReader
+        public bool TryParseMessage(in ReadOnlySequence<byte> input, ref SequencePosition consumed, ref SequencePosition examined, out Frame message)
+        {
+            // Header
+            if (_header == null)
+            {
+                if (!TryParseHeader(input, out var headerSequence))
+                {
+                    message = default;
+                    return false;
+                }
+
+                _header = _createHeader(headerSequence);
+            }
+
+            if (!TryParsePayload(input, out var payloadSequence))
+            {
+                message = default;
+                return false;
+            }
+
+            consumed = payloadSequence.End;
+            examined = consumed;
+            message = new Frame(_header, payloadSequence);
+            _header = null;
+            return true;
+        }
+
+        private bool TryParseHeader(in ReadOnlySequence<byte> input, out ReadOnlySequence<byte> headerSequence)
+        {
+            if (input.Length < _headerLength)
+            {
+                headerSequence = default;
+                return false;
+            }
+
+            headerSequence = input.Slice(0, _headerLength);
+            return true;
+        }
+
+        private bool TryParsePayload(in ReadOnlySequence<byte> input, out ReadOnlySequence<byte> payloadSequence)
+        {
+            int messageLength = _headerLength + _header.PayloadLength;
+            if (input.Length < messageLength)
+            {
+                payloadSequence = default;
+                return false;
+            }
+
+            payloadSequence = input.Slice(_headerLength, _header.PayloadLength);
+            return true;
+        }
+        #endregion
+
+        #region IMessageWriter
+        public void WriteMessage(Frame message, IBufferWriter<byte> output)
+        {
+            // Header
+            output.Write(message.Header.AsSpan());
+
+            // Payload
+            foreach (var payloadSegment in message.Payload)
+            {
+                output.Write(payloadSegment.Span);
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Bedrock.Framework.Experimental/Protocols/Http1RequestMessageReader.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Http1RequestMessageReader.cs
@@ -54,7 +54,7 @@ namespace Bedrock.Framework.Protocols
                     goto case State.Headers;
 
                 case State.Headers:
-                    while (sequenceReader.TryReadTo(out var headerLine, NewLine))
+                    while (sequenceReader.TryReadTo(out ReadOnlySequence<byte> headerLine, NewLine))
                     {
                         if (headerLine.Length == 0)
                         {

--- a/src/Bedrock.Framework.Experimental/Protocols/Http1ResponseMessageReader.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Http1ResponseMessageReader.cs
@@ -59,7 +59,7 @@ namespace Bedrock.Framework.Protocols
                     goto case State.Headers;
 
                 case State.Headers:
-                    while (sequenceReader.TryReadTo(out var headerLine, NewLine))
+                    while (sequenceReader.TryReadTo(out ReadOnlySequence<byte> headerLine, NewLine))
                     {
                         if (headerLine.Length == 0)
                         {

--- a/src/Bedrock.Framework/Bedrock.Framework.csproj
+++ b/src/Bedrock.Framework/Bedrock.Framework.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipelines" Version="6.0.0-rc.2.21480.5" />
+    <PackageReference Include="System.IO.Pipelines" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bedrock.Framework/Bedrock.Framework.csproj
+++ b/src/Bedrock.Framework/Bedrock.Framework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageDescription>High performance, low level networking APIs for building custom severs and clients.</PackageDescription>
     <Authors>David Fowler</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipelines" Version="4.7.2" />
+    <PackageReference Include="System.IO.Pipelines" Version="6.0.0-rc.2.21480.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
   </ItemGroup>
 </Project>

--- a/src/Bedrock.Framework/Bedrock.Framework.csproj
+++ b/src/Bedrock.Framework/Bedrock.Framework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <PackageDescription>High performance, low level networking APIs for building custom severs and clients.</PackageDescription>
     <Authors>David Fowler</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
   </ItemGroup>
 </Project>

--- a/src/Bedrock.Framework/Protocols/ProtocolReader.cs
+++ b/src/Bedrock.Framework/Protocols/ProtocolReader.cs
@@ -241,6 +241,27 @@ namespace Bedrock.Framework.Protocols
             _hasMessage = false;
         }
 
+        public void CancelPendingRead()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+
+            _reader.CancelPendingRead();
+            _isCanceled = true;
+        }
+
+        public async ValueTask CompleteAsync()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+
+            await _reader.CompleteAsync();
+        }
+
         public ValueTask DisposeAsync()
         {
             _disposed = true;

--- a/src/Bedrock.Framework/Protocols/ProtocolWriter.cs
+++ b/src/Bedrock.Framework/Protocols/ProtocolWriter.cs
@@ -95,6 +95,26 @@ namespace Bedrock.Framework.Protocols
             }
         }
 
+        public void CancelPendingFlush()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _writer.CancelPendingFlush();
+        }
+
+        public async ValueTask CompleteAsync()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            await _writer.CompleteAsync();
+        }
+
         public async ValueTask DisposeAsync()
         {
             await _semaphore.WaitAsync().ConfigureAwait(false);

--- a/tests/Bedrock.Framework.Benchmarks/Bedrock.Framework.Benchmarks.csproj
+++ b/tests/Bedrock.Framework.Benchmarks/Bedrock.Framework.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Bedrock.Framework.Benchmarks/Bedrock.Framework.Benchmarks.csproj
+++ b/tests/Bedrock.Framework.Benchmarks/Bedrock.Framework.Benchmarks.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Bedrock.Framework.Tests/Bedrock.Framework.Tests.csproj
+++ b/tests/Bedrock.Framework.Tests/Bedrock.Framework.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Bedrock.Framework.Tests/Bedrock.Framework.Tests.csproj
+++ b/tests/Bedrock.Framework.Tests/Bedrock.Framework.Tests.csproj
@@ -1,16 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Bedrock.Framework.Tests/ProtocolTests.cs
+++ b/tests/Bedrock.Framework.Tests/ProtocolTests.cs
@@ -274,7 +274,7 @@ namespace Bedrock.Framework.Tests
 
             var cts = new CancellationTokenSource();
             cts.Cancel();
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await reader.ReadAsync(protocol, cts.Token));
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await reader.ReadAsync(protocol, cts.Token));
 
             await connection.Application.Output.WriteAsync(data);
 


### PR DESCRIPTION
Fixes #132 

Added a framing protocol for a scenario when a frame is variable sized and the header's `PayloadLength` field is used to split the incoming stream. Plus implemented a sample client and server for this protocol.