### PR TITLE
Improve logging performance

### DIFF
--- a/samples/ClientApplication/ClientApplication.csproj
+++ b/samples/ClientApplication/ClientApplication.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.0-rc.2.21480.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.0" />
     <PackageReference Include="MQTTnet.AspNetCore" Version="3.1.0" />
   </ItemGroup>
   

--- a/samples/ClientApplication/ClientApplication.csproj
+++ b/samples/ClientApplication/ClientApplication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,8 +14,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.0.0" />
-    <PackageReference Include="MQTTnet.AspNetCore" Version="3.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.0-rc.2.21480.10" />
+    <PackageReference Include="MQTTnet.AspNetCore" Version="3.1.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/samples/ServerApplication/MqttApplication.cs
+++ b/samples/ServerApplication/MqttApplication.cs
@@ -19,7 +19,7 @@ namespace ServerApplication
         {
             while (true)
             {
-                var packet = await adapter.ReceivePacketAsync(Timeout.InfiniteTimeSpan, default);
+                var packet = await adapter.ReceivePacketAsync(default);
 
                 switch (packet)
                 {
@@ -29,8 +29,7 @@ namespace ServerApplication
                             ReturnCode = MqttConnectReturnCode.ConnectionAccepted,
                             ReasonCode = MqttConnectReasonCode.Success,
                             IsSessionPresent = false
-                        }, Timeout.InfiniteTimeSpan,
-                        default);
+                        }, default);
                         break;
                     case MqttDisconnectPacket disconnectPacket:
                         break;
@@ -48,7 +47,7 @@ namespace ServerApplication
                         };
                         ack.ReasonCodes.Add(MqttSubscribeReasonCode.GrantedQoS0);
 
-                        await adapter.SendPacketAsync(ack, Timeout.InfiniteTimeSpan, default);
+                        await adapter.SendPacketAsync(ack, default);
                         break;
                     default:
                         break;

--- a/samples/ServerApplication/ServerApplication.csproj
+++ b/samples/ServerApplication/ServerApplication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MQTTnet.AspNetCore" Version="3.0.8" />
+    <PackageReference Include="MQTTnet.AspNetCore" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bedrock.Framework.Experimental/Bedrock.Framework.Experimental.csproj
+++ b/src/Bedrock.Framework.Experimental/Bedrock.Framework.Experimental.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageDescription>Experimental protocols and transports for Bedrock.Framework.</PackageDescription>
     <Authors>David Fowler</Authors>
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="6.0.0-rc.2.21480.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
   </ItemGroup>
 </Project>

--- a/src/Bedrock.Framework.Experimental/Bedrock.Framework.Experimental.csproj
+++ b/src/Bedrock.Framework.Experimental/Bedrock.Framework.Experimental.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="6.0.0-rc.2.21480.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bedrock.Framework.Experimental/Protocols/Http1RequestMessageReader.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Http1RequestMessageReader.cs
@@ -54,7 +54,7 @@ namespace Bedrock.Framework.Protocols
                     goto case State.Headers;
 
                 case State.Headers:
-                    while (sequenceReader.TryReadTo(out var headerLine, NewLine))
+                    while (sequenceReader.TryReadTo(out ReadOnlySequence<byte> headerLine, NewLine))
                     {
                         if (headerLine.Length == 0)
                         {

--- a/src/Bedrock.Framework.Experimental/Protocols/Http1ResponseMessageReader.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Http1ResponseMessageReader.cs
@@ -59,7 +59,7 @@ namespace Bedrock.Framework.Protocols
                     goto case State.Headers;
 
                 case State.Headers:
-                    while (sequenceReader.TryReadTo(out var headerLine, NewLine))
+                    while (sequenceReader.TryReadTo(out ReadOnlySequence<byte> headerLine, NewLine))
                     {
                         if (headerLine.Length == 0)
                         {

--- a/src/Bedrock.Framework/Bedrock.Framework.csproj
+++ b/src/Bedrock.Framework/Bedrock.Framework.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipelines" Version="6.0.0-rc.2.21480.5" />
+    <PackageReference Include="System.IO.Pipelines" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bedrock.Framework/Bedrock.Framework.csproj
+++ b/src/Bedrock.Framework/Bedrock.Framework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageDescription>High performance, low level networking APIs for building custom severs and clients.</PackageDescription>
     <Authors>David Fowler</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipelines" Version="4.7.2" />
+    <PackageReference Include="System.IO.Pipelines" Version="6.0.0-rc.2.21480.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
   </ItemGroup>
 </Project>

--- a/src/Bedrock.Framework/Middleware/ConnectionBuilderExtensions.cs
+++ b/src/Bedrock.Framework/Middleware/ConnectionBuilderExtensions.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
-using Bedrock.Framework.Infrastructure;
 using Bedrock.Framework.Middleware.Tls;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.ObjectPool;
 
 namespace Bedrock.Framework
 {
@@ -17,11 +16,16 @@ namespace Bedrock.Framework
         /// <summary>
         /// Emits verbose logs for bytes read from and written to the connection.
         /// </summary>
-        public static TBuilder UseConnectionLogging<TBuilder>(this TBuilder builder, string loggerName = null, ILoggerFactory loggerFactory = null, LoggingFormatter loggingFormatter = null) where TBuilder : IConnectionBuilder
+        public static TBuilder UseConnectionLogging<TBuilder>(this TBuilder builder, string loggerName = null, ILoggerFactory loggerFactory = null, ObjectPool<StringBuilder> stringBuilderPool = null, LoggingFormatter loggingFormatter = null) where TBuilder : IConnectionBuilder
         {
             loggerFactory ??= builder.ApplicationServices.GetRequiredService<ILoggerFactory>();
             var logger = loggerName == null ? loggerFactory.CreateLogger<LoggingConnectionMiddleware>() : loggerFactory.CreateLogger(loggerName);
-            builder.Use(next => new LoggingConnectionMiddleware(next, logger, loggingFormatter).OnConnectionAsync);
+            if (stringBuilderPool == null)
+            {
+                var objectPoolProvider = new DefaultObjectPoolProvider();
+                stringBuilderPool = objectPoolProvider.CreateStringBuilderPool();
+            }
+            builder.Use(next => new LoggingConnectionMiddleware(next, logger, stringBuilderPool, loggingFormatter).OnConnectionAsync);
             return builder;
         }
 

--- a/src/Bedrock.Framework/Middleware/Internal/LoggingStream.cs
+++ b/src/Bedrock.Framework/Middleware/Internal/LoggingStream.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ObjectPool;
 
 namespace Bedrock.Framework.Infrastructure
 {
@@ -14,69 +15,34 @@ namespace Bedrock.Framework.Infrastructure
     {
         private readonly Stream _inner;
         private readonly ILogger _logger;
+        private readonly ObjectPool<StringBuilder> _stringBuilderPool;
         private readonly LoggingFormatter _logFormatter;
 
-        public LoggingStream(Stream inner, ILogger logger, LoggingFormatter logFormatter = null)
+        public LoggingStream(Stream inner, ILogger logger, ObjectPool<StringBuilder> stringBuilderPool, LoggingFormatter logFormatter = null)
         {
             _inner = inner;
             _logger = logger;
+            _stringBuilderPool = stringBuilderPool;
             _logFormatter = logFormatter;
         }
 
-        public override bool CanRead
-        {
-            get
-            {
-                return _inner.CanRead;
-            }
-        }
+        public override bool CanRead => _inner.CanRead;
 
-        public override bool CanSeek
-        {
-            get
-            {
-                return _inner.CanSeek;
-            }
-        }
+        public override bool CanSeek => _inner.CanSeek;
 
-        public override bool CanWrite
-        {
-            get
-            {
-                return _inner.CanWrite;
-            }
-        }
+        public override bool CanWrite => _inner.CanWrite;
 
-        public override long Length
-        {
-            get
-            {
-                return _inner.Length;
-            }
-        }
+        public override long Length => _inner.Length;
 
         public override long Position
         {
-            get
-            {
-                return _inner.Position;
-            }
-
-            set
-            {
-                _inner.Position = value;
-            }
+            get => _inner.Position;
+            set => _inner.Position = value;
         }
 
-        public override void Flush()
-        {
-            _inner.Flush();
-        }
+        public override void Flush() => _inner.Flush();
 
-        public override Task FlushAsync(CancellationToken cancellationToken)
-        {
-            return _inner.FlushAsync(cancellationToken);
-        }
+        public override Task FlushAsync(CancellationToken cancellationToken) => _inner.FlushAsync(cancellationToken);
 
         public override int Read(byte[] buffer, int offset, int count)
         {
@@ -140,7 +106,7 @@ namespace Bedrock.Framework.Infrastructure
             return _inner.WriteAsync(source, cancellationToken);
         }
 
-        private void Log(string method, ReadOnlySpan<byte> buffer)
+        private void Log(in string method, in ReadOnlySpan<byte> buffer)
         {
             if (_logFormatter != null)
             {
@@ -153,20 +119,20 @@ namespace Bedrock.Framework.Infrastructure
                 return;
             }
 
-            var builder = new StringBuilder();
+            var builder = _stringBuilderPool.Get();
             builder.AppendLine($"{method}[{buffer.Length}]");
-            var charBuilder = new StringBuilder();
+            var charBuilder = _stringBuilderPool.Get();
 
             // Write the hex
             for (int i = 0; i < buffer.Length; i++)
             {
                 builder.Append(buffer[i].ToString("X2"));
-                builder.Append(" ");
+                builder.Append(' ');
 
                 var bufferChar = (char)buffer[i];
                 if (char.IsControl(bufferChar))
                 {
-                    charBuilder.Append(".");
+                    charBuilder.Append('.');
                 }
                 else
                 {
@@ -175,15 +141,15 @@ namespace Bedrock.Framework.Infrastructure
 
                 if ((i + 1) % 16 == 0)
                 {
-                    builder.Append("  ");
-                    builder.Append(charBuilder.ToString());
+                    builder.Append(' ', 2);
+                    builder.Append(charBuilder);
                     builder.AppendLine();
                     charBuilder.Clear();
                 }
                 else if ((i + 1) % 8 == 0)
                 {
-                    builder.Append(" ");
-                    charBuilder.Append(" ");
+                    builder.Append(' ');
+                    charBuilder.Append(' ');
                 }
             }
 
@@ -193,32 +159,25 @@ namespace Bedrock.Framework.Infrastructure
                 builder.Append(string.Empty.PadRight(2 + (3 * (16 - charBuilder.Length))));
                 // extra for space after 8th byte
                 if (charBuilder.Length < 8)
-                    builder.Append(" ");
-                builder.Append(charBuilder.ToString());
+                {
+                    builder.Append(' ');
+                }
+                builder.Append(charBuilder);
             }
 
             _logger.LogDebug(builder.ToString());
+
+            _stringBuilderPool.Return(builder);
+            _stringBuilderPool.Return(charBuilder);
         }
 
         // The below APM methods call the underlying Read/WriteAsync methods which will still be logged.
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-        {
-            return TaskToApm.Begin(ReadAsync(buffer, offset, count), callback, state);
-        }
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) => TaskToApm.Begin(ReadAsync(buffer, offset, count), callback, state);
 
-        public override int EndRead(IAsyncResult asyncResult)
-        {
-            return TaskToApm.End<int>(asyncResult);
-        }
+        public override int EndRead(IAsyncResult asyncResult) => TaskToApm.End<int>(asyncResult);
 
-        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-        {
-            return TaskToApm.Begin(WriteAsync(buffer, offset, count), callback, state);
-        }
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) => TaskToApm.Begin(WriteAsync(buffer, offset, count), callback, state);
 
-        public override void EndWrite(IAsyncResult asyncResult)
-        {
-            TaskToApm.End(asyncResult);
-        }
+        public override void EndWrite(IAsyncResult asyncResult) => TaskToApm.End(asyncResult);
     }
 }

--- a/tests/Bedrock.Framework.Benchmarks/Bedrock.Framework.Benchmarks.csproj
+++ b/tests/Bedrock.Framework.Benchmarks/Bedrock.Framework.Benchmarks.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Bedrock.Framework.Tests/Bedrock.Framework.Tests.csproj
+++ b/tests/Bedrock.Framework.Tests/Bedrock.Framework.Tests.csproj
@@ -1,16 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Bedrock.Framework.Tests/ProtocolTests.cs
+++ b/tests/Bedrock.Framework.Tests/ProtocolTests.cs
@@ -274,7 +274,7 @@ namespace Bedrock.Framework.Tests
 
             var cts = new CancellationTokenSource();
             cts.Cancel();
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await reader.ReadAsync(protocol, cts.Token));
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await reader.ReadAsync(protocol, cts.Token));
 
             await connection.Application.Output.WriteAsync(data);
 


### PR DESCRIPTION
Optimization of the LoggingStream.
- StringBuilder Pool
- `in` keyword
- Append `char` instead of `string`.