### PR TITLE
Add Variable Size Length Fielded Protocol

### DIFF
--- a/samples/ClientApplication/ClientApplication.csproj
+++ b/samples/ClientApplication/ClientApplication.csproj
@@ -6,6 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\ServerApplication\Framing\VariableSizeLengthFielded\Header.cs" Link="Framing\VariableSizeLengthFielded\Header.cs" />
+    <Compile Include="..\ServerApplication\Framing\VariableSizeLengthFielded\HeaderFactory.cs" Link="Framing\VariableSizeLengthFielded\HeaderFactory.cs" />
+    <Compile Include="..\ServerApplication\Framing\VariableSizeLengthFielded\Helper.cs" Link="Framing\VariableSizeLengthFielded\Helper.cs" />
     <Compile Include="..\ServerApplication\LengthPrefixedProtocol.cs" Link="LengthPrefixedProtocol.cs" />
   </ItemGroup>
 
@@ -20,6 +23,10 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\src\Bedrock.Framework.Experimental\Bedrock.Framework.Experimental.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Folder Include="Framing\VariableSizeLengthFielded\" />
   </ItemGroup>
 
 </Project>

--- a/samples/ClientApplication/Program.cs
+++ b/samples/ClientApplication/Program.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 using Bedrock.Framework;
+using Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFielded;
 using Bedrock.Framework.Experimental.Protocols.RabbitMQ;
 using Bedrock.Framework.Experimental.Protocols.Memcached;
 using Bedrock.Framework.Protocols;
@@ -18,6 +19,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Protocols;
 using Bedrock.Framework.Experimental.Protocols.RabbitMQ.Methods;
+using ServerApplication.Framing.VariableSizeLengthFielded;
 
 namespace ClientApplication
 {
@@ -39,9 +41,10 @@ namespace ClientApplication
             Console.WriteLine("4. Echo Server With TLS enabled");
             Console.WriteLine("5. In Memory Transport Echo Server and client");
             Console.WriteLine("6. Length prefixed custom binary protocol");
-            Console.WriteLine("7. Talk to local docker dameon");
-            Console.WriteLine("8. Memcached protocol");
-            Console.WriteLine("9. RebbitMQ protocol");
+            Console.WriteLine("7. Header prefixed protocol");
+            Console.WriteLine("8. Talk to local docker daemon");
+            Console.WriteLine("9. Memcached protocol");
+            Console.WriteLine("0. RabbitMQ protocol");
 
             while (true)
             {
@@ -79,15 +82,20 @@ namespace ClientApplication
                 }
                 else if (keyInfo.Key == ConsoleKey.D7)
                 {
+                    Console.WriteLine("Variable size length fielded protocol.");
+                    await VariableSizeLengthFieldedProtocol();
+                }
+                else if (keyInfo.Key == ConsoleKey.D8)
+                {
                     Console.WriteLine("Talk to local docker daemon");
                     await DockerDaemon(serviceProvider);
                 }
-                else if (keyInfo.Key == ConsoleKey.D8)
+                else if (keyInfo.Key == ConsoleKey.D9)
                 {
                     Console.WriteLine("Send Request To Memcached");
                     await MemcachedProtocol(serviceProvider);
                 }
-                else if (keyInfo.Key == ConsoleKey.D9)
+                else if (keyInfo.Key == ConsoleKey.D0)
                 {
                     Console.WriteLine("RabbitMQ test");
                     await RabbitMQProtocol(serviceProvider);
@@ -351,6 +359,51 @@ namespace ClientApplication
 
                 reader.Advance();
             }
+        }
+
+        private static async Task VariableSizeLengthFieldedProtocol()
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.SetMinimumLevel(LogLevel.Debug);
+                builder.AddConsole();
+            });
+
+            var client = new ClientBuilder()
+                .UseSockets()
+                .UseConnectionLogging(loggerFactory: loggerFactory)
+                .Build();
+
+            await using var connection = await client.ConnectAsync(new IPEndPoint(IPAddress.Loopback, 5006));
+            Console.WriteLine($"Connected to {connection.RemoteEndPoint}");
+            Console.WriteLine("Enter 'c' to close the connection.");
+
+            var headerFactory = new HeaderFactory();
+
+            var protocol = new VariableSizeLengthFieldedProtocol(Helper.HeaderLength, (headerSequence) => headerFactory.CreateHeader(headerSequence));
+            await using var writer = connection.CreateWriter();
+
+            while (true)
+            {
+                Console.WriteLine("Enter the text: ");
+                var line = Console.ReadLine();
+                if (line.Equals("c"))
+                {
+                    break;
+                }
+
+                Console.WriteLine("Enter a number as custom data: ");
+                int someCustomData = int.Parse(Console.ReadLine());
+
+                var payload = Encoding.UTF8.GetBytes(line);
+                var header = headerFactory.CreateHeader(payload.Length, someCustomData);
+                var frame = new Frame(header, payload);
+
+                await writer.WriteAsync(protocol, frame);
+            }
+
+            connection.Abort();
+            await connection.DisposeAsync();
         }
 
         private static async Task DockerDaemon(IServiceProvider serviceProvider)

--- a/samples/ServerApplication/Framing/VariableSizeLengthFielded/Header.cs
+++ b/samples/ServerApplication/Framing/VariableSizeLengthFielded/Header.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFielded;
+
+namespace ServerApplication.Framing.VariableSizeLengthFielded
+{
+    internal class Header : IHeader
+    {
+        public int PayloadLength { get; }
+        public int SomeCustomData { get; }
+
+        public Header(int payloadLength, int someCustomData)
+        {
+            PayloadLength = payloadLength;
+            SomeCustomData = someCustomData;
+        }
+
+        public Header(ReadOnlySpan<byte> headerAsSpan)
+        {
+            PayloadLength = BitConverter.ToInt32(headerAsSpan.Slice(0, 4));
+            SomeCustomData = BitConverter.ToInt32(headerAsSpan.Slice(4));
+        }
+
+        public ReadOnlySpan<byte> AsSpan()
+        {
+            var payloadLengthAsArray = BitConverter.GetBytes(PayloadLength);
+            var someCustomDataAsArray = BitConverter.GetBytes(SomeCustomData);
+
+            byte[] header = new byte[Helper.HeaderLength];
+            header[0] = payloadLengthAsArray[0];
+            header[1] = payloadLengthAsArray[1];
+            header[2] = payloadLengthAsArray[2];
+            header[3] = payloadLengthAsArray[3];
+            header[4] = someCustomDataAsArray[0];
+            header[5] = someCustomDataAsArray[1];
+            header[6] = someCustomDataAsArray[2];
+            header[7] = someCustomDataAsArray[3];
+            return header.AsSpan();
+        }
+
+        public override string ToString() => $"Payload length: {PayloadLength} - Some custom data: {SomeCustomData}";
+    }
+}

--- a/samples/ServerApplication/Framing/VariableSizeLengthFielded/HeaderFactory.cs
+++ b/samples/ServerApplication/Framing/VariableSizeLengthFielded/HeaderFactory.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Buffers;
+
+namespace ServerApplication.Framing.VariableSizeLengthFielded
+{
+    internal class HeaderFactory
+    {
+        public Header CreateHeader(int payloadLength, int someCustomData) => new Header(payloadLength, someCustomData);
+
+        public Header CreateHeader(in ReadOnlySequence<byte> headerSequence)
+        {
+            if (headerSequence.IsSingleSegment)
+            {
+                return CreateHeader(headerSequence.FirstSpan);
+            }
+            else
+            {
+                Span<byte> headerData = stackalloc byte[Helper.HeaderLength];
+                headerSequence.CopyTo(headerData);
+                return CreateHeader(headerData);
+            }
+        }
+
+        public Header CreateHeader(in ReadOnlySpan<byte> headerData) => new Header(headerData);
+    }
+}

--- a/samples/ServerApplication/Framing/VariableSizeLengthFielded/HeaderPrefixedApplication.cs
+++ b/samples/ServerApplication/Framing/VariableSizeLengthFielded/HeaderPrefixedApplication.cs
@@ -1,0 +1,57 @@
+﻿using System.Buffers;
+using System.Text;
+using System.Threading.Tasks;
+using Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFielded;
+using Bedrock.Framework.Protocols;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Logging;
+
+namespace ServerApplication.Framing.VariableSizeLengthFielded
+{
+    internal class HeaderPrefixedApplication : ConnectionHandler
+    {
+        private readonly ILogger _logger;
+        private readonly HeaderFactory _headerFactory;
+
+        public HeaderPrefixedApplication(ILogger<MyCustomProtocol> logger, HeaderFactory headerFactory)
+        {
+            _logger = logger ?? throw new System.ArgumentNullException(nameof(logger));
+            _headerFactory = headerFactory ?? throw new System.ArgumentNullException(nameof(headerFactory));
+        }
+
+        public override async Task OnConnectedAsync(ConnectionContext connection)
+        {
+            _logger.LogInformation("{ConnectionId} connected.", connection.ConnectionId);
+
+            // Use a header prefixed protocol
+            var protocol = new VariableSizeLengthFieldedProtocol(Helper.HeaderLength, (headerSequence) => _headerFactory.CreateHeader(headerSequence));
+            var reader = connection.CreateReader();
+            var writer = connection.CreateWriter();
+
+            while (true)
+            {
+                try
+                {
+                    var result = await reader.ReadAsync(protocol);
+                    var message = result.Message;
+
+#if NETCOREAPP3_1
+                    _logger.LogInformation("Message received - Header: ({Header}) -  Payload: ({Payload})", message.Header, Encoding.UTF8.GetString(message.Payload.ToArray()));
+#elif NET6_0_OR_GREATER
+                    _logger.LogInformation("Message received - Header: ({Header}) -  Payload: ({Payload})", message.Header, Encoding.UTF8.GetString(message.Payload));
+#endif
+                    if (result.IsCompleted)
+                    {
+                        break;
+                    }
+                }
+                finally
+                {
+                    reader.Advance();
+                }
+            }
+
+            _logger.LogInformation("{ConnectionId} disconnected.", connection.ConnectionId);
+        }
+    }
+}

--- a/samples/ServerApplication/Framing/VariableSizeLengthFielded/Helper.cs
+++ b/samples/ServerApplication/Framing/VariableSizeLengthFielded/Helper.cs
@@ -1,0 +1,7 @@
+﻿namespace ServerApplication.Framing.VariableSizeLengthFielded
+{
+    internal static class Helper
+    {
+        public static int HeaderLength => 8;
+    }
+}

--- a/samples/ServerApplication/Program.cs
+++ b/samples/ServerApplication/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using ServerApplication.Framing.VariableSizeLengthFielded;
 
 namespace ServerApplication
 {
@@ -23,6 +24,7 @@ namespace ServerApplication
             });
 
             services.AddSignalR();
+            services.AddSingleton<HeaderFactory>();
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -56,8 +58,13 @@ namespace ServerApplication
                                 })
                                 .UseConnectionLogging().UseConnectionHandler<EchoServerApplication>());
 
+                            // Length prefixed server
                             sockets.Listen(IPAddress.Loopback, 5005,
                                 builder => builder.UseConnectionLogging().UseConnectionHandler<MyCustomProtocol>());
+
+                            // Header prefixed server
+                            sockets.Listen(IPAddress.Loopback, 5006,
+                                builder => builder.UseConnectionLogging().UseConnectionHandler<HeaderPrefixedApplication>());
                         })
                         .Build();
 

--- a/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/Frame.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/Frame.cs
@@ -1,0 +1,20 @@
+﻿using System.Buffers;
+
+namespace Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFielded
+{
+    public readonly struct Frame
+    {
+        public IHeader Header { get; }
+        public ReadOnlySequence<byte> Payload { get; }
+
+        public Frame(IHeader header, byte[] payload) : this(header, new ReadOnlySequence<byte>(payload))
+        {
+        }
+
+        public Frame(IHeader header, ReadOnlySequence<byte> payload)
+        {
+            Header = header;
+            Payload = payload;
+        }
+    }
+}

--- a/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/IHeader.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/IHeader.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFielded
+{
+    public interface IHeader
+    {
+        public int PayloadLength { get; }
+
+        public ReadOnlySpan<byte> AsSpan();
+    }
+}

--- a/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/VariableSizeLengthFieldedProtocol.cs
+++ b/src/Bedrock.Framework.Experimental/Protocols/Framing/VariableSizeLengthFielded/VariableSizeLengthFieldedProtocol.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Buffers;
+using Bedrock.Framework.Protocols;
+
+namespace Bedrock.Framework.Experimental.Protocols.Framing.VariableSizeLengthFielded
+{
+    public class VariableSizeLengthFieldedProtocol : IMessageReader<Frame>, IMessageWriter<Frame>
+    {
+        private readonly int _headerLength;
+        private readonly Func<ReadOnlySequence<byte>, IHeader> _createHeader;
+
+        private IHeader? _header;
+
+        public VariableSizeLengthFieldedProtocol(int headerLength, Func<ReadOnlySequence<byte>, IHeader> createHeader)
+        {
+            if (headerLength <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(headerLength), "Header length must be greater than 0.");
+            }
+
+            _headerLength = headerLength;
+            _createHeader = createHeader ?? throw new ArgumentNullException(nameof(createHeader));
+        }
+
+        #region IMessageReader
+        public bool TryParseMessage(in ReadOnlySequence<byte> input, ref SequencePosition consumed, ref SequencePosition examined, out Frame message)
+        {
+            // Header
+            if (_header == null)
+            {
+                if (!TryParseHeader(input, out var headerSequence))
+                {
+                    message = default;
+                    return false;
+                }
+
+                _header = _createHeader(headerSequence);
+            }
+
+            if (!TryParsePayload(input, out var payloadSequence))
+            {
+                message = default;
+                return false;
+            }
+
+            consumed = payloadSequence.End;
+            examined = consumed;
+            message = new Frame(_header, payloadSequence);
+            _header = null;
+            return true;
+        }
+
+        private bool TryParseHeader(in ReadOnlySequence<byte> input, out ReadOnlySequence<byte> headerSequence)
+        {
+            if (input.Length < _headerLength)
+            {
+                headerSequence = default;
+                return false;
+            }
+
+            headerSequence = input.Slice(0, _headerLength);
+            return true;
+        }
+
+        private bool TryParsePayload(in ReadOnlySequence<byte> input, out ReadOnlySequence<byte> payloadSequence)
+        {
+            int messageLength = _headerLength + _header.PayloadLength;
+            if (input.Length < messageLength)
+            {
+                payloadSequence = default;
+                return false;
+            }
+
+            payloadSequence = input.Slice(_headerLength, _header.PayloadLength);
+            return true;
+        }
+        #endregion
+
+        #region IMessageWriter
+        public void WriteMessage(Frame message, IBufferWriter<byte> output)
+        {
+            // Header
+            output.Write(message.Header.AsSpan());
+
+            // Payload
+            foreach (var payloadSegment in message.Payload)
+            {
+                output.Write(payloadSegment.Span);
+            }
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
Fixes #132

Added a framing protocol for a scenario when a frame is variable sized and the header's `PayloadLength` field is used to split the incoming stream. Plus implemented a sample client and server for this protocol.

Clean and conflict free version of #133