### PR TITLE
Switch from RNGCryptoServiceProvider to RandomNumberGenerator.

### DIFF
--- a/src/Bedrock.Framework/Protocols/WebSockets/WebSocketHeader.cs
+++ b/src/Bedrock.Framework/Protocols/WebSockets/WebSocketHeader.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 
@@ -13,7 +12,7 @@ namespace Bedrock.Framework.Protocols.WebSockets
         /// <summary>
         /// An instance of a thread-safe and cryptographically sound random number generator.
         /// </summary>
-        private readonly static RandomNumberGenerator _rng = new RNGCryptoServiceProvider();
+        private readonly static RandomNumberGenerator _rng = RandomNumberGenerator.Create();
 
         /// <summary>
         /// Whether or not this is the final frame in the message.

--- a/tests/Bedrock.Framework.Tests/Protocols/WebSocketPayloadReaderTests.cs
+++ b/tests/Bedrock.Framework.Tests/Protocols/WebSocketPayloadReaderTests.cs
@@ -15,7 +15,7 @@ namespace Bedrock.Framework.Protocols.WebSockets.Tests
 {
     public class WebSocketPayloadReaderTests
     {
-        private RNGCryptoServiceProvider _rng = new RNGCryptoServiceProvider();
+        private RandomNumberGenerator _rng = RandomNumberGenerator.Create();
 
         [Fact]
         public void SingleSegmentSequenceWorks()


### PR DESCRIPTION
On .NET 6 RNGCryptoServiceProvider is marked as obsolete. I switched it to the recommanded RandomNumberGenerator static class.