### PR TITLE
Update Nerdbank.GitVersioning for arm64 support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup Condition="$(IsPackable) == 'true'">
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.3.37</Version>
+      <Version>3.5.119</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>


### PR DESCRIPTION
Trying to build the Bedrock samples on an M1 Mac currently fails because of `Nerdbank.GitVersioning` doesn't support arm 64. I have updated to the latest version, which does support it (fixed in https://github.com/dotnet/Nerdbank.GitVersioning/issues/505). 

Not sure how to test it, but it builds and `dotnet pack...` produces a nuget package as expected.