### PR TITLE
buffer parses data when it has it

### DIFF
--- a/src/Bedrock.Framework/Protocols/ProtocolReader.cs
+++ b/src/Bedrock.Framework/Protocols/ProtocolReader.cs
@@ -58,7 +58,7 @@ namespace Bedrock.Framework.Protocols
             }
 
             // We have a buffer, test to see if there's any message left in the buffer
-            if (TryParseMessage(maximumMessageSize, reader, _buffer, out var protocolMessage))
+            if (_buffer.Length > 0 && TryParseMessage(maximumMessageSize, reader, _buffer, out var protocolMessage))
             {
                 _hasMessage = true;
                 return new ValueTask<ProtocolReadResult<TReadMessage>>(new ProtocolReadResult<TReadMessage>(protocolMessage, _isCanceled, isCompleted: false));


### PR DESCRIPTION
<img width="1209" alt="image" src="https://github.com/davidfowl/BedrockFramework/assets/39239954/3e00d348-12fd-41fd-a230-0971e87b3db7">
<img width="1075" alt="image" src="https://github.com/davidfowl/BedrockFramework/assets/39239954/5fda63ce-113c-46d6-9d0b-6bb2822105b4">


Parse when there is still data in the buffer.