### PR TITLE
Remove unnecessary SourceLink PackageReferences

### DIFF
--- a/src/Bedrock.Framework.Experimental/Bedrock.Framework.Experimental.csproj
+++ b/src/Bedrock.Framework.Experimental/Bedrock.Framework.Experimental.csproj
@@ -31,7 +31,6 @@
   </Choose>
 	
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.146" />
   </ItemGroup>
 

--- a/src/Bedrock.Framework/Bedrock.Framework.csproj
+++ b/src/Bedrock.Framework/Bedrock.Framework.csproj
@@ -25,7 +25,6 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.146" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Microsoft.SourceLink is automatically included with .NET 8+ SDKs so we override the latest package version by defining it here.

src: https://github.com/dotnet/sourcelink?tab=readme-ov-file#using-source-link-in-net-projects